### PR TITLE
Fixed issue for identical action calls

### DIFF
--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/instrumentation/config/callsorting/GenericActionCallSorterTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/instrumentation/config/callsorting/GenericActionCallSorterTest.java
@@ -138,6 +138,18 @@ public class GenericActionCallSorterTest {
         }
 
         @Test
+        void testIdenticalActions() throws Exception {
+            List<ActionCallConfig> input = Arrays.asList(
+                    new TestCallBuilder("A").build(),
+                    new TestCallBuilder("A").build()
+            );
+
+            List<String> result = getNames(scheduler.orderActionCalls(input));
+
+            assertThat(result).containsExactly("A", "A");
+        }
+
+        @Test
         void testDAGOrdering() throws Exception {
 
             List<ActionCallConfig> input = Arrays.asList(


### PR DESCRIPTION
If two rules used exactly the same ActionCallConfig, this caused the hook builder to fail:
When sorting the actions, normal Hashmaps where used instead of IdentityHashMaps, which caused this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/439)
<!-- Reviewable:end -->
