### PR TITLE
Follow-up for #570 - Fixed bug in the reducer request counts

### DIFF
--- a/components/inspectit-ocelot-configurationserver-ui/src/redux/ducks/configuration/reducers.js
+++ b/components/inspectit-ocelot-configurationserver-ui/src/redux/ducks/configuration/reducers.js
@@ -81,7 +81,7 @@ const configurationReducer = createReducer(initialState)({
             ...initialState
         };
     },
-    [types.FETCH_FILE_STARTED]: decrementPendingRequests,
+    [types.FETCH_FILE_STARTED]: incrementPendingRequests,
     [types.FETCH_FILE_FAILURE]: decrementPendingRequests,
     [types.FETCH_FILE_SUCCESS]: (state, action) => {
         const { fileContent } = action.payload;


### PR DESCRIPTION
Fixes a bug that does not show file content after changing in the tree. Bug reproducible only when switching between editable files (non-defaults)..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/621)
<!-- Reviewable:end -->
