### PR TITLE
close #647 Add hostname param to docker-compose-prometheus

### DIFF
--- a/inspectit-ocelot-demo/docker-compose-prometheus-jaeger.yml
+++ b/inspectit-ocelot-demo/docker-compose-prometheus-jaeger.yml
@@ -4,6 +4,7 @@ services:
   agent:
     image: inspectit/inspectit-ocelot-agent:${INSPECTIT_OCELOT_VERSION}
     container_name: agent
+    hostname: agent
     mem_limit: 128M
     volumes:
       - agent-vol:/agent
@@ -23,6 +24,7 @@ services:
   config-server:
     image: openapm/spring-petclinic-config-server:inspectit-oce-demo
     container_name: config-server
+    hostname: config-server
     depends_on:
       - ocelot-config-server
       - agent
@@ -45,6 +47,7 @@ services:
   discovery-server:
     image: openapm/spring-petclinic-discovery-server:inspectit-oce-demo
     container_name: discovery-server
+    hostname: discovery-server
     environment:
       - INSPECTIT_SERVICE_NAME=discovery-server
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
@@ -69,6 +72,7 @@ services:
   customers-service:
     image: openapm/spring-petclinic-customers-service:inspectit-oce-demo
     container_name: customers-service
+    hostname: customers-service
     environment:
       - INSPECTIT_SERVICE_NAME=customers-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
@@ -94,6 +98,7 @@ services:
   visits-service:
     image: openapm/spring-petclinic-visits-service:inspectit-oce-demo
     container_name: visits-service
+    hostname: visits-service
     environment:
       - INSPECTIT_SERVICE_NAME=visits-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
@@ -119,6 +124,7 @@ services:
   vets-service:
     image: openapm/spring-petclinic-vets-service:inspectit-oce-demo
     container_name: vets-service
+    hostname: vets-service
     environment:
       - INSPECTIT_SERVICE_NAME=vets-service
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
@@ -144,6 +150,7 @@ services:
   api-gateway:
     image: openapm/spring-petclinic-api-gateway:inspectit-oce-demo
     container_name: api-gateway
+    hostname: api-gateway
     environment:
       - INSPECTIT_SERVICE_NAME=api-gateway
       - INSPECTIT_CONFIG_HTTP_URL=http://ocelot-config-server:8090/api/v1/agent/configuration
@@ -169,6 +176,7 @@ services:
   load:
     image: inspectit/spring-petclinic-load:1.0
     container_name: load-generator
+    hostname: load-generator
 
   jaeger:
     image: jaegertracing/all-in-one:1.6


### PR DESCRIPTION
The param "hostname" is needed in docker-compose file, so the inspectIT configsrv could see the different agents in docker environment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/648)
<!-- Reviewable:end -->
