### PR TITLE
Closes #637 - Exposing count of reported resource timing elements

### DIFF
--- a/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/beacon/recorder/BeaconRecorder.java
+++ b/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/beacon/recorder/BeaconRecorder.java
@@ -1,0 +1,18 @@
+package rocks.inspectit.oce.eum.server.beacon.recorder;
+
+import rocks.inspectit.oce.eum.server.beacon.Beacon;
+
+/**
+ * Interface for all components acting as {@link BeaconRecorder}.
+ * BeaconRecorder are intended to record custom complicated metrics from a fully-processed Beacon.
+ */
+public interface BeaconRecorder {
+
+    /**
+     * Records arbitrary metrics from given {@link Beacon}
+     *
+     * @param beacon Fully-processed beacon
+     */
+    void record(Beacon beacon);
+
+}

--- a/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/beacon/recorder/BeaconRecorder.java
+++ b/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/beacon/recorder/BeaconRecorder.java
@@ -9,7 +9,8 @@ import rocks.inspectit.oce.eum.server.beacon.Beacon;
 public interface BeaconRecorder {
 
     /**
-     * Records arbitrary metrics from given {@link Beacon}
+     * Records arbitrary metrics from given the {@link Beacon}. This method will be invoked within the scope where
+     * global tags are already added.
      *
      * @param beacon Fully-processed beacon
      */

--- a/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/beacon/recorder/ResourceTimingBeaconRecorder.java
+++ b/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/beacon/recorder/ResourceTimingBeaconRecorder.java
@@ -1,0 +1,346 @@
+package rocks.inspectit.oce.eum.server.beacon.recorder;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opencensus.common.Scope;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpRequest;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+import rocks.inspectit.oce.eum.server.beacon.Beacon;
+import rocks.inspectit.oce.eum.server.metrics.MeasuresAndViewsManager;
+import rocks.inspectit.ocelot.config.model.metrics.definition.MetricDefinitionSettings;
+import rocks.inspectit.ocelot.config.model.metrics.definition.ViewDefinitionSettings;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Stream;
+
+/**
+ * This {@link BeaconRecorder} processes plain resource timing entry from the {@link Beacon} and exposes metric that:
+ * <ul>
+ *     <li>reports number of resources loaded sliced by type, cross-origin and cached tags</li>
+ * </ul>
+ * <p>
+ * The impl depends heavily on the Boomerang compression of the resource timing entries in the beacon. Please read
+ * <a href="https://developer.akamai.com/tools/boomerang/docs/BOOMR.plugins.ResourceTiming.html">ResourceTiming</a>
+ * Boomerang documentation first.
+ */
+@Component
+@ConditionalOnProperty(value = "inspectit-eum-server.resource-timing.enabled", havingValue = "true")
+@RequiredArgsConstructor
+@Slf4j
+public class ResourceTimingBeaconRecorder implements BeaconRecorder {
+
+    /**
+     * Metric definition for the resource timing total metric.
+     */
+    private static final MetricDefinitionSettings RESOURCE_TIMING_TOTAL;
+
+    static {
+        Map<String, Boolean> tags = new HashMap<>();
+        tags.put("initiatorType", true);
+        tags.put("cached", true);
+        tags.put("crossOrigin", true);
+
+        RESOURCE_TIMING_TOTAL = MetricDefinitionSettings.builder()
+                .type(MetricDefinitionSettings.MeasureType.LONG)
+                .unit("ms")
+                .view("resource_timing_total/COUNT", ViewDefinitionSettings.builder()
+                        .tags(tags)
+                        .aggregation(ViewDefinitionSettings.Aggregation.COUNT)
+                        .build()
+                )
+                .build();
+    }
+
+    /**
+     * Object mapper used to read the resource timing
+     */
+    @Autowired
+    private final ObjectMapper objectMapper;
+
+    /**
+     * {@link MeasuresAndViewsManager} for exposing metrics.
+     */
+    @Autowired
+    private final MeasuresAndViewsManager measuresAndViewsManager;
+
+    /**
+     * Init metric(s).
+     */
+    @PostConstruct
+    public void initMetric() {
+        measuresAndViewsManager.updateMetrics("resource_timing_total", RESOURCE_TIMING_TOTAL);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Parses the <code>restiming</code> entry from the beacon and exposes metric(s) about resource timing if parsing is
+     * success.
+     */
+    @Override
+    public void record(Beacon beacon) {
+        // this is the URL where the resources have been loaded
+        String url = beacon.get("u");
+
+        Optional.ofNullable(beacon.get("restiming"))
+                .ifPresent(resourceTiming -> this.resourceTimingResults(resourceTiming)
+                        .forEach(rs -> this.record(rs, url))
+                );
+    }
+
+    /**
+     * Records one {@link ResourceTimingEntry} to the exposed metric(s).
+     *
+     * @param resourceTimingEntry entry
+     * @param url                 URL of the page where the resource has been loaded from.
+     */
+    private void record(ResourceTimingEntry resourceTimingEntry, String url) {
+        Map<String, String> extra = new HashMap<>();
+        boolean sameOrigin = isSameOrigin(url, resourceTimingEntry.url);
+        extra.put("crossOrigin", String.valueOf(!sameOrigin));
+        extra.put("initiatorType", resourceTimingEntry.getInitiatorType().toString());
+        // TODO is this OK, only setting cached if it's same origin, otherwise we can not know
+        if (sameOrigin) {
+            extra.put("cached", String.valueOf(resourceTimingEntry.isCached(true)));
+        }
+
+        try (Scope scope = measuresAndViewsManager.getTagContext(extra).buildScoped()) {
+            // TODO I think we should already collect there the load time, thus we would have a COUNT and a SUM of time
+            //  we would have most of the stuff needed then
+            //  and it would make tests more reliable then now
+            measuresAndViewsManager.recordMeasure("resource_timing_total", RESOURCE_TIMING_TOTAL, 1L);
+        }
+    }
+
+    /**
+     * Takes Boomerang resource timing JSON and returns stream of found {@link ResourceTimingEntry}s.
+     *
+     * @param resourceTiming json
+     * @return stream
+     */
+    private Stream<ResourceTimingEntry> resourceTimingResults(String resourceTiming) {
+        JsonNode rootNode;
+        try {
+            rootNode = objectMapper.readTree(resourceTiming);
+        } catch (IOException e) {
+            log.error("Error converting resource timing json to tree.", e);
+            return Stream.empty();
+        }
+
+        return findAllTimingValuesAsText(rootNode).entrySet()
+                .stream()
+                .flatMap(entry -> this.resolveResourceTimingStringValue(entry.getKey(), entry.getValue()));
+
+    }
+
+    /**
+     * Helper to construct map of resource URLs to resource timing details.
+     *
+     * @param node root node
+     * @return Map where keys are resource URLs and values are the Boomerang compressed resource timing string.
+     */
+    private Map<String, String> findAllTimingValuesAsText(JsonNode node) {
+        Map<String, String> map = new HashMap<>();
+        this.findAllTimingValuesAsText(node, map, "");
+        return map;
+    }
+
+    private void findAllTimingValuesAsText(JsonNode node, Map<String, String> foundSoFar, String prefix) {
+        if (node.isValueNode()) {
+            if (node.isTextual()) {
+                foundSoFar.put(prefix, node.textValue());
+            }
+        } else {
+            node.fields().forEachRemaining(entry -> this.findAllTimingValuesAsText(entry.getValue(), foundSoFar, prefix + entry.getKey()));
+        }
+
+    }
+
+    /**
+     * Maps one resource URL and it's timing given as the Boomerang compressed string to the stream of {@link ResourceTimingEntry}.
+     * <p>
+     * Note that one compressed string can contain multiple loads of the same entry. This method ignores any additional
+     * data (transfer size, image size, etc) from the Boomerang string.
+     *
+     * @param url   URL of the loaded resource.
+     * @param value Boomerang compressed resource timing string for a single entry
+     * @return
+     */
+    private Stream<ResourceTimingEntry> resolveResourceTimingStringValue(String url, String value) {
+        return Stream.of(value)
+                // split by pipe, as pipe separates same resource load times if executed more than once
+                .flatMap(possibleMultipleValue -> {
+                    String[] split = possibleMultipleValue.split("\\|");
+                    return Arrays.stream(split);
+                })
+                .flatMap(singeValue -> ResourceTimingEntry.from(url, singeValue).map(Stream::of).orElseGet(Stream::empty));
+    }
+
+    /**
+     * Checks if two URLs are considered as same origin. Based on {@link org.springframework.web.util.WebUtils#isSameOrigin(HttpRequest)}.
+     *
+     * @param u1 first url
+     * @param u2 second url
+     * @return Returns true if two urls are considered as same-origin
+     * @see org.springframework.web.util.WebUtils#isSameOrigin(HttpRequest)
+     * @see 'https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy'
+     */
+    private static boolean isSameOrigin(String u1, String u2) {
+        UriComponents uriComponents1 = UriComponentsBuilder.fromUriString(u1).build();
+        UriComponents uriComponents2 = UriComponentsBuilder.fromUriString(u2).build();
+
+        return Objects.equals(uriComponents1.getScheme(), uriComponents2.getScheme()) &&
+                Objects.equals(uriComponents1.getHost(), uriComponents2.getHost()) &&
+                getPort(uriComponents1.getScheme(), uriComponents1.getPort()) == getPort(uriComponents2.getScheme(), uriComponents2.getPort());
+    }
+
+    private static int getPort(@Nullable String scheme, int port) {
+        if (port == -1) {
+            if ("http".equals(scheme) || "ws".equals(scheme)) {
+                port = 80;
+            } else if ("https".equals(scheme) || "wss".equals(scheme)) {
+                port = 443;
+            }
+        }
+        return port;
+    }
+
+    @Value
+    @Builder
+    public static class ResourceTimingEntry {
+
+        /**
+         * Url of the resource.
+         */
+        String url;
+
+        /**
+         * Initiator type.
+         */
+        InitiatorType initiatorType;
+
+        /**
+         * Timings array in following order:
+         * <br>
+         * <code>timings = "[startTime],[responseEnd],[responseStart],[requestStart],[connectEnd],[secureConnectionStart],[connectStart],[domainLookupEnd],[domainLookupStart],[redirectEnd],[redirectStart]"</code>
+         * <p>
+         * Note that array does not need to be fully populated if entries from the end are missing.
+         */
+        Integer[] timings;
+
+        /**
+         * Cached resources only have 2 timing values if considered as same-origin requests.
+         *
+         * @param sameOrigin If this is considered as same origin resource loading
+         * @return If cached or not.
+         */
+        public boolean isCached(boolean sameOrigin) {
+            if (this.timings == null || this.timings.length < 3) {
+                return sameOrigin;
+            }
+            return false;
+        }
+
+        /**
+         * Constructs the {@link ResourceTimingEntry} from a single (non-piped) string value.
+         * <p>
+         * Will resolve to empty if it contains only additional data.
+         *
+         * @return ResourceTimingEntry as optional
+         */
+        public static Optional<ResourceTimingEntry> from(String url, String value) {
+            // check if this string contains additional data
+            // if so cut it from processing
+            String toProcess = value;
+            int additionalDataIndex = value.indexOf('*');
+            if (additionalDataIndex > -1) {
+                toProcess = value.substring(0, additionalDataIndex);
+            }
+
+            if (StringUtils.isEmpty(toProcess)) {
+                return Optional.empty();
+            }
+
+            // initiator is always first char
+            InitiatorType initiatorType = InitiatorType.from(toProcess.charAt(0));
+
+            // then split by comma to get all timings
+            String[] timingsAsBase36Strings = toProcess.substring(1).split(",");
+
+            // then convert timings in base36 to int values
+            // if empty then it's zero
+            Integer[] timings = Arrays.stream(timingsAsBase36Strings)
+                    .map(v -> StringUtils.isEmpty(v) ? 0 : Integer.parseInt(v, 36))
+                    .toArray(Integer[]::new);
+
+            // then build the entry
+            return Optional.of(ResourceTimingEntry.builder()
+                    .url(url)
+                    .initiatorType((initiatorType))
+                    .timings(timings)
+                    .build()
+            );
+        }
+
+    }
+
+    /**
+     * Initiator type represented by a char.
+     *
+     * @see 'https://developer.akamai.com/tools/boomerang/docs/BOOMR.plugins.ResourceTiming.html'
+     */
+    public enum InitiatorType {
+        OTHER('0'),
+        IMG('1'),
+        LINK('2'),
+        SCRIPT('3'),
+        CSS('4'),
+        XML_HTTP_REQUEST('5'),
+        HTML('6'),
+        IMAGE('7'),
+        BEACON('8'),
+        FETCH('9'),
+        IFRAME('a'),
+        BODY('b'),
+        INPUT('c'),
+        OBJECT('d'),
+        VIDEO('e'),
+        AUDIO('f'),
+        SOURCE('g'),
+        TRACK('h'),
+        EMBED('i'),
+        EVENT_SOURCE('j');
+
+        private char identifier;
+
+        InitiatorType(char identifier) {
+            this.identifier = identifier;
+        }
+
+        /**
+         * Returns the {@link InitiatorType} represented by this char. If not found {@link #OTHER} is returned.
+         *
+         * @param c identifier
+         * @return {@link InitiatorType}
+         */
+        public static InitiatorType from(char c) {
+            return Arrays.stream(InitiatorType.values())
+                    .filter(initiatorType -> initiatorType.identifier == c)
+                    .findFirst()
+                    .orElse(OTHER);
+        }
+
+    }
+}

--- a/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/configuration/model/EumServerConfiguration.java
+++ b/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/configuration/model/EumServerConfiguration.java
@@ -45,4 +45,11 @@ public class EumServerConfiguration {
      */
     @Valid
     private ExportersSettings exporters;
+
+    /**
+     * The resource timing settings.
+     */
+    @Valid
+    private ResourceTimingSettings resourceTiming;
+
 }

--- a/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/configuration/model/ResourceTimingSettings.java
+++ b/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/configuration/model/ResourceTimingSettings.java
@@ -1,0 +1,18 @@
+package rocks.inspectit.oce.eum.server.configuration.model;
+
+import lombok.Data;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Resource timing settings.
+ */
+@Data
+@Validated
+public class ResourceTimingSettings {
+
+    /**
+     * If resource timing is enabled or not.
+     */
+    private boolean enabled = true;
+
+}

--- a/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/configuration/model/ResourceTimingSettings.java
+++ b/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/configuration/model/ResourceTimingSettings.java
@@ -13,6 +13,6 @@ public class ResourceTimingSettings {
     /**
      * If resource timing is enabled or not.
      */
-    private boolean enabled = true;
+    private boolean enabled;
 
 }

--- a/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/metrics/BeaconMetricManager.java
+++ b/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/metrics/BeaconMetricManager.java
@@ -7,13 +7,16 @@ import io.opencensus.tags.TagValue;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 import rocks.inspectit.oce.eum.server.arithmetic.RawExpression;
 import rocks.inspectit.oce.eum.server.beacon.Beacon;
+import rocks.inspectit.oce.eum.server.beacon.recorder.BeaconRecorder;
 import rocks.inspectit.oce.eum.server.configuration.model.BeaconMetricDefinitionSettings;
 import rocks.inspectit.oce.eum.server.configuration.model.BeaconRequirement;
 import rocks.inspectit.oce.eum.server.configuration.model.EumServerConfiguration;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -28,6 +31,9 @@ public class BeaconMetricManager {
 
     @Autowired
     private MeasuresAndViewsManager measuresAndViewsManager;
+
+    @Autowired(required = false)
+    private List<BeaconRecorder> beaconRecorders;
 
     /**
      * Maps metric definitions to expressions.
@@ -52,6 +58,13 @@ public class BeaconMetricManager {
                 successful = true;
             } else {
                 log.debug("Skipping beacon because requirements are not fulfilled.");
+            }
+        }
+
+        // allow each beacon recorder to record stuff
+        if (!CollectionUtils.isEmpty(beaconRecorders)) {
+            try (Scope scope = getTagContextForBeacon(beacon).buildScoped()) {
+                beaconRecorders.forEach(beaconRecorder -> beaconRecorder.record(beacon));
             }
         }
 

--- a/components/inspectit-ocelot-eum-server/src/main/resources/application.yml
+++ b/components/inspectit-ocelot-eum-server/src/main/resources/application.yml
@@ -133,6 +133,10 @@ inspectit-eum-server:
             tags:
               is_error: true
 
+  # settings for exposing resource timing metrics
+  resource-timing:
+    enabled: true
+
 # ACTUATOR PROPERTIES
 management:
   # Whether to enable or disable all endpoints by default.

--- a/components/inspectit-ocelot-eum-server/src/test/java/rocks/inspectit/oce/eum/server/beacon/recorder/ResourceTimingBeaconRecorderTest.java
+++ b/components/inspectit-ocelot-eum-server/src/test/java/rocks/inspectit/oce/eum/server/beacon/recorder/ResourceTimingBeaconRecorderTest.java
@@ -1,0 +1,188 @@
+package rocks.inspectit.oce.eum.server.beacon.recorder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opencensus.tags.Tags;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import rocks.inspectit.oce.eum.server.beacon.Beacon;
+import rocks.inspectit.oce.eum.server.metrics.MeasuresAndViewsManager;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ResourceTimingBeaconRecorderTest {
+
+    ResourceTimingBeaconRecorder recorder;
+
+    @Mock
+    MeasuresAndViewsManager measuresAndViewsManager;
+
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void init() {
+        lenient().when(measuresAndViewsManager.getTagContext(any())).thenReturn(Tags.getTagger().emptyBuilder());
+
+        objectMapper = new ObjectMapper();
+        recorder = new ResourceTimingBeaconRecorder(objectMapper, measuresAndViewsManager);
+    }
+
+    @Nested
+    class Record {
+
+        @Captor
+        ArgumentCaptor<Map<String, String>> tagsCaptor;
+
+        @Test
+        public void noResourceTimingInfo() {
+            Beacon beacon = Beacon.of(Collections.emptyMap());
+
+            recorder.record(beacon);
+
+            verifyNoMoreInteractions(measuresAndViewsManager);
+        }
+
+        @Test
+        public void notAJson() {
+            Beacon beacon = Beacon.of(Collections.singletonMap("restiming", "This is not a valid json"));
+
+            recorder.record(beacon);
+
+            verifyNoMoreInteractions(measuresAndViewsManager);
+        }
+
+        @Test
+        public void nestedResources() {
+            String json = "" +
+                    "{\n" +
+                    "  \"http\": {\n" +
+                    "    \"://myhost/\": {\n" +
+                    "      \"boomerang/plugins/\": {\n" +
+                    "        \"r\": {\n" +
+                    "          \"t.js\": \"32o,2u,2q,25*1d67,9s,wdu*20\",\n" +
+                    "          \"estiming.js\": \"02p,2w,2p,24*1efk,9z,y2i*20\"\n" +
+                    "        }\n" +
+                    "      }\n" +
+                    "    },\n" +
+                    "    \"s://www.google.de/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png\": \"*02k,7k,1y,a2|180,3l\"\n" +
+                    "  }\n" +
+                    "}";
+            Map<String, String> fields = new HashMap<>();
+            fields.put("u", "http://myhost/somepage.html");
+            fields.put("restiming", json);
+            Beacon beacon = Beacon.of(fields);
+
+            recorder.record(beacon);
+
+            verify(measuresAndViewsManager, atLeastOnce()).getTagContext(tagsCaptor.capture());
+            verify(measuresAndViewsManager, times(3)).recordMeasure(eq("resource_timing_total"), any(), eq(1L));
+            verifyNoMoreInteractions(measuresAndViewsManager);
+
+            assertThat(tagsCaptor.getAllValues()).hasSize(3)
+                    // t.js
+                    .anySatisfy(map -> assertThat(map).hasSize(3)
+                            .containsEntry("initiatorType", "SCRIPT")
+                            .containsEntry("crossOrigin", "false")
+                            .containsEntry("cached", "false")
+                    )
+                    // estiming.js
+                    .anySatisfy(map -> assertThat(map).hasSize(3)
+                            .containsEntry("initiatorType", "OTHER")
+                            .containsEntry("crossOrigin", "false")
+                            .containsEntry("cached", "false")
+                    )
+                    // googlelogo_color_272x92dp.png
+                    .anySatisfy(map -> assertThat(map).hasSize(2)
+                            .containsEntry("initiatorType", "IMG")
+                            .containsEntry("crossOrigin", "true")
+                    );
+
+        }
+
+        @Test
+        public void pipedData() {
+            // intentionally change the initiator
+            String json = "" +
+                    "{\n" +
+                    "  \"https://www.google.de/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png\": \"*02k,7k,1y,a2|180,3l|280,3l\"\n" +
+                    "}";
+            Map<String, String> fields = new HashMap<>();
+            fields.put("u", "http://myhost/somepage.html");
+            fields.put("restiming", json);
+            Beacon beacon = Beacon.of(fields);
+            recorder.record(beacon);
+
+            verify(measuresAndViewsManager, atLeastOnce()).getTagContext(tagsCaptor.capture());
+            verify(measuresAndViewsManager, times(2)).recordMeasure(eq("resource_timing_total"), any(), eq(1L));
+            verifyNoMoreInteractions(measuresAndViewsManager);
+
+            assertThat(tagsCaptor.getAllValues()).hasSize(2)
+                    // first
+                    .anySatisfy(map -> assertThat(map).hasSize(2)
+                            .containsEntry("initiatorType", "IMG")
+                            .containsEntry("crossOrigin", "true")
+                    )
+                    // second
+                    .anySatisfy(map -> assertThat(map).hasSize(2)
+                            .containsEntry("initiatorType", "LINK")
+                            .containsEntry("crossOrigin", "true")
+                    );
+        }
+
+        @Test
+        public void onlyAdditionalData() {
+            // intentionally change the initiator
+            String json = "" +
+                    "{\n" +
+                    "  \"https://www.google.de/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png\": \"*02k,7k,1y,a2\"\n" +
+                    "}";
+            Map<String, String> fields = new HashMap<>();
+            fields.put("u", "http://myhost/somepage.html");
+            fields.put("restiming", json);
+            Beacon beacon = Beacon.of(fields);
+            recorder.record(beacon);
+
+            verifyNoMoreInteractions(measuresAndViewsManager);
+        }
+
+        @Test
+        public void wrongInitiator() {
+            // intentionally change the initiator
+            String json = "" +
+                    "{\n" +
+                    "  \"https://www.google.de/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png\": \"w80,3l\"\n" +
+                    "}";
+            Map<String, String> fields = new HashMap<>();
+            fields.put("u", "http://myhost/somepage.html");
+            fields.put("restiming", json);
+            Beacon beacon = Beacon.of(fields);
+            recorder.record(beacon);
+
+            verify(measuresAndViewsManager, atLeastOnce()).getTagContext(tagsCaptor.capture());
+            verify(measuresAndViewsManager, times(1)).recordMeasure(eq("resource_timing_total"), any(), eq(1L));
+            verifyNoMoreInteractions(measuresAndViewsManager);
+
+            assertThat(tagsCaptor.getAllValues()).hasSize(1)
+                    // first
+                    .anySatisfy(map -> assertThat(map).hasSize(2)
+                            .containsEntry("initiatorType", "OTHER")
+                            .containsEntry("crossOrigin", "true")
+                    );
+        }
+
+    }
+
+}

--- a/components/inspectit-ocelot-eum-server/src/test/java/rocks/inspectit/oce/eum/server/beacon/recorder/ResourceTimingBeaconRecorderTest.java
+++ b/components/inspectit-ocelot-eum-server/src/test/java/rocks/inspectit/oce/eum/server/beacon/recorder/ResourceTimingBeaconRecorderTest.java
@@ -89,7 +89,7 @@ class ResourceTimingBeaconRecorderTest {
             recorder.record(beacon);
 
             verify(measuresAndViewsManager, atLeastOnce()).getTagContext(tagsCaptor.capture());
-            verify(measuresAndViewsManager, times(4)).recordMeasure(eq("resource_timing_total"), any(), eq(1L));
+            verify(measuresAndViewsManager, times(4)).recordMeasure(eq("resource_time"), any(), eq(1L));
             verifyNoMoreInteractions(measuresAndViewsManager);
 
             assertThat(tagsCaptor.getAllValues()).hasSize(4)
@@ -133,7 +133,7 @@ class ResourceTimingBeaconRecorderTest {
             recorder.record(beacon);
 
             verify(measuresAndViewsManager, atLeastOnce()).getTagContext(tagsCaptor.capture());
-            verify(measuresAndViewsManager, times(2)).recordMeasure(eq("resource_timing_total"), any(), eq(1L));
+            verify(measuresAndViewsManager, times(2)).recordMeasure(eq("resource_time"), any(), eq(1L));
             verifyNoMoreInteractions(measuresAndViewsManager);
 
             assertThat(tagsCaptor.getAllValues()).hasSize(2)
@@ -179,7 +179,7 @@ class ResourceTimingBeaconRecorderTest {
             recorder.record(beacon);
 
             verify(measuresAndViewsManager, atLeastOnce()).getTagContext(tagsCaptor.capture());
-            verify(measuresAndViewsManager, times(1)).recordMeasure(eq("resource_timing_total"), any(), eq(1L));
+            verify(measuresAndViewsManager, times(1)).recordMeasure(eq("resource_time"), any(), eq(1L));
             verifyNoMoreInteractions(measuresAndViewsManager);
 
             assertThat(tagsCaptor.getAllValues()).hasSize(1)

--- a/components/inspectit-ocelot-eum-server/src/test/java/rocks/inspectit/oce/eum/server/beacon/recorder/ResourceTimingBeaconRecorderTest.java
+++ b/components/inspectit-ocelot-eum-server/src/test/java/rocks/inspectit/oce/eum/server/beacon/recorder/ResourceTimingBeaconRecorderTest.java
@@ -70,6 +70,7 @@ class ResourceTimingBeaconRecorderTest {
                     "{\n" +
                     "  \"http\": {\n" +
                     "    \"://myhost/\": {\n" +
+                    "      \"|\": \"6,2\",\n" +
                     "      \"boomerang/plugins/\": {\n" +
                     "        \"r\": {\n" +
                     "          \"t.js\": \"32o,2u,2q,25*1d67,9s,wdu*20\",\n" +
@@ -88,10 +89,16 @@ class ResourceTimingBeaconRecorderTest {
             recorder.record(beacon);
 
             verify(measuresAndViewsManager, atLeastOnce()).getTagContext(tagsCaptor.capture());
-            verify(measuresAndViewsManager, times(3)).recordMeasure(eq("resource_timing_total"), any(), eq(1L));
+            verify(measuresAndViewsManager, times(4)).recordMeasure(eq("resource_timing_total"), any(), eq(1L));
             verifyNoMoreInteractions(measuresAndViewsManager);
 
-            assertThat(tagsCaptor.getAllValues()).hasSize(3)
+            assertThat(tagsCaptor.getAllValues()).hasSize(4)
+                    // |
+                    .anySatisfy(map -> assertThat(map).hasSize(3)
+                            .containsEntry("initiatorType", "HTML")
+                            .containsEntry("crossOrigin", "false")
+                            .containsEntry("cached", "true")
+                    )
                     // t.js
                     .anySatisfy(map -> assertThat(map).hasSize(3)
                             .containsEntry("initiatorType", "SCRIPT")

--- a/inspectit-ocelot-documentation/docs/enduser-monitoring/eum-server-configuration.md
+++ b/inspectit-ocelot-documentation/docs/enduser-monitoring/eum-server-configuration.md
@@ -277,7 +277,7 @@ inspectit-eum-server:
       - COUNTRY_CODE
 ```
 
-## Resource timings
+## Resource Timings
 
 The EUM server can extract information about the resources timings which are reported as part of the Boomerang beacon field `restiming`.
 The resource timing information is decompressed from the beacon and exposed as part of the `resource_time` metric.

--- a/inspectit-ocelot-documentation/docs/enduser-monitoring/eum-server-configuration.md
+++ b/inspectit-ocelot-documentation/docs/enduser-monitoring/eum-server-configuration.md
@@ -277,6 +277,20 @@ inspectit-eum-server:
       - COUNTRY_CODE
 ```
 
+## Resource timings
+
+The EUM server can extract information about the resources timings which are reported as part of the Boomerang beacon field `restiming`.
+The resource timing information is decompressed from the beacon and exposed as part of the `resource_time` metric.
+This metric contains following tags:
+
+| Tag | Description |
+| --- | --- |
+| `initiatorType` | The type of the element initiating the loading of the resource. See [all initiator types](https://developer.akamai.com/tools/boomerang/docs/BOOMR.plugins.ResourceTiming.html#.INITIATOR_TYPES). |
+| `crossOrigin` | If a resource loading is considered as cross-origin request. See [more information about CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS). |
+| `cached` | If a resource was cached and loaded from the browser disk or memory storage. Note that cached tag will only be set for same-origin requests, as some resource timing  metrics are restricted and will not be provided cross-origin unless the Timing-Allow-Origin header permits. |
+
+The resource timing processing is enabled by default and can be disabled by setting the property `inspectit-eum-server.resource-timing.enabled` to `false.`
+
 ## Exporters
 
 The EUM server comes with the same Prometheus and InfluxDB exporter as the Ocelot agent.


### PR DESCRIPTION
Few hits for the review:

* I think without reading a full docs from the Boomerang, it's impossible to review this, especially the parsing of the compressed string for resource timing
* As discussed with @JonasKunz I added a `BeaconRecorder` interfaces that acts on fully processed beacon, extended the manager for this purpose
* Currently I am only counting resources.. However, I would advise that we immediately report the load times instead. We will have the COUNT and SUM views, so we would have both the count on how many, plus the loading times.. Imo there is no reason to start only with counting.. Plus, let's agree on the metric name not sure if `resource_timing_total` is good one. Note that now I could not test the `timing` values, as these are not reported, thus even the tests would be more complete.
* I added the `crossOrigin` tag as well, think this is important. I report `cached` tag only if it's same origin, otherwise we can not know.
* There are few `TODO`s to be discussed
* Documentation comes on top when we agree on the final metrics

I am here for questions. Would be great if somebody can additionally test this on a meaningful HTMl page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/651)
<!-- Reviewable:end -->
