### PR TITLE
Closes #602 - Option to use pre authentication on the configuration se…

### DIFF
--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/config/model/AuthProxySettings.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/config/model/AuthProxySettings.java
@@ -1,0 +1,27 @@
+package rocks.inspectit.ocelot.config.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Settings for the configuration of the to let a HTTP reverse proxy handling authentication.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthProxySettings {
+
+    /**
+     * If auth proxy is enabled.
+     */
+    private boolean enabled;
+
+    /**
+     * The request header where the username is stored.
+     */
+    private String principalRequestHeader;
+
+}

--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/config/model/SecuritySettings.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/config/model/SecuritySettings.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.Valid;
 import javax.validation.constraints.AssertFalse;
+import javax.validation.constraints.NotNull;
 
 /**
  * Security settings of the configuration server.
@@ -28,6 +29,13 @@ public class SecuritySettings {
      */
     @Valid
     private LdapSettings ldap;
+
+    /**
+     * The settings for the authentication proxy.
+     */
+    @Valid
+    @NotNull
+    private AuthProxySettings authProxy;
 
     /**
      * If enabled, all authorized and unauthorized accesses attempts to secured endpoints will be logged.

--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/security/config/AuthProxySecurityConfiguration.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/security/config/AuthProxySecurityConfiguration.java
@@ -1,0 +1,86 @@
+package rocks.inspectit.ocelot.security.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.AuthenticationUserDetailsService;
+import org.springframework.security.core.userdetails.UserDetailsByNameServiceWrapper;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.security.web.authentication.preauth.RequestHeaderAuthenticationFilter;
+import rocks.inspectit.ocelot.filters.AccessLogFilter;
+
+import java.util.Collections;
+
+/**
+ * Spring security configuration when proxy authentication is enabled.
+ */
+@ConditionalOnProperty(value = "inspectit-config-server.security.auth-proxy.enabled", havingValue = "true")
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(securedEnabled = true)
+public class AuthProxySecurityConfiguration extends SharedSecurityConfiguration {
+
+    @Autowired
+    private AccessLogFilter accessLogFilter;
+
+    @Autowired
+    private UserDetailsService userDetailsService;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        super.configure(http);
+
+        //TODO I see no reason to enable any other auth in addition here
+        // I also don't get why is there both basic and token auth by default now, it should be token with the auth and resource servers
+        // so token is used to get resources and form auth (with ot without ldap) is used for login purposes
+        // now everything is mixed imo
+
+        http
+                // specific stuff for auth proxy
+                .exceptionHandling().authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                .and()
+                .addFilterAfter(preAuthenticationFilter(), RequestHeaderAuthenticationFilter.class)
+                .addFilterBefore(accessLogFilter.getFilter(), RequestHeaderAuthenticationFilter.class);
+
+
+    }
+
+    @Bean
+    public RequestHeaderAuthenticationFilter preAuthenticationFilter() {
+        RequestHeaderAuthenticationFilter requestHeaderAuthenticationFilter = new RequestHeaderAuthenticationFilter();
+        requestHeaderAuthenticationFilter.setPrincipalRequestHeader(serverSettings.getSecurity().getAuthProxy().getPrincipalRequestHeader());
+        requestHeaderAuthenticationFilter.setAuthenticationManager(authenticationManager());
+        requestHeaderAuthenticationFilter.setExceptionIfHeaderMissing(false);
+        return requestHeaderAuthenticationFilter;
+    }
+
+    @Override
+    protected AuthenticationManager authenticationManager() {
+        return new ProviderManager(Collections.singletonList(authenticationProvider()));
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        PreAuthenticatedAuthenticationProvider authenticationProvider = new PreAuthenticatedAuthenticationProvider();
+        authenticationProvider.setPreAuthenticatedUserDetailsService(userDetailsServiceWrapper());
+        authenticationProvider.setThrowExceptionWhenTokenRejected(false);
+
+        return authenticationProvider;
+    }
+
+    @Bean
+    public AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> userDetailsServiceWrapper() {
+        // note that if ldap is active the user details service to use here will the ldap one
+        return new UserDetailsByNameServiceWrapper<>(userDetailsService);
+    }
+
+}

--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/security/config/SecurityConfiguration.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/security/config/SecurityConfiguration.java
@@ -1,19 +1,15 @@
 package rocks.inspectit.ocelot.security.config;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
-import rocks.inspectit.ocelot.config.model.InspectitServerSettings;
 import rocks.inspectit.ocelot.config.model.LdapSettings;
 import rocks.inspectit.ocelot.filters.AccessLogFilter;
 import rocks.inspectit.ocelot.security.jwt.JwtTokenFilter;
@@ -23,14 +19,13 @@ import rocks.inspectit.ocelot.security.userdetails.LocalUserDetailsService;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Collections;
 
-import static rocks.inspectit.ocelot.security.userdetails.LocalUserDetailsService.DEFAULT_ACCESS_USER_ROLE;
-
 /**
- * Spring security configuration enabling authentication on all except excluded endpoints.
+ * This is default configuration that enables basic & token auth and optionally ldap authentication.
  */
+@ConditionalOnProperty(value = "inspectit-config-server.security.auth-proxy.enabled", havingValue = "false", matchIfMissing = true)
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(securedEnabled = true)
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+public class SecurityConfiguration extends SharedSecurityConfiguration {
 
     @Autowired
     private ApplicationEventPublisher eventPublisher;
@@ -47,38 +42,11 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Autowired
     private LocalUserDetailsService localUserDetailsService;
 
-    @Autowired
-    @VisibleForTesting
-    InspectitServerSettings serverSettings;
-
-    @Override
-    public void configure(WebSecurity web) {
-        web.ignoring().antMatchers(
-                "/v2/api-docs",
-                "/configuration/**",
-                "/csrf",
-                "/",
-                "/ui/**",
-                "/actuator/**",
-                "/swagger*/**",
-                "/webjars/**",
-                "/api/v1/agent/configuration");
-    }
-
     @Override
     protected void configure(HttpSecurity http) throws Exception {
+        super.configure(http);
+
         http
-                .csrf().disable()
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-
-                .and()
-                .cors()
-
-                .and()
-                .authorizeRequests()
-                .anyRequest().hasRole(getAccessRole())
-
-                .and()
                 // Custom authentication endpoint to prevent sending the "WWW-Authenticate" which causes Browsers to open the basic authentication dialog.
                 // See the following post: https://stackoverflow.com/a/50023070/2478009
                 .httpBasic().authenticationEntryPoint((req, resp, authException) -> resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getMessage()))
@@ -92,19 +60,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 ).addFilterBefore(accessLogFilter.getFilter(), JwtTokenFilter.class);
     }
 
-    /**
-     * Returns the role name which is required by users to get access to the secured API endpoints.
-     * In case LDAP is not used, a constant role name is used, otherwise the configured role name of the LDAP settings is used.
-     *
-     * @return the role name to use
-     */
-    private String getAccessRole() {
-        if (serverSettings.getSecurity().isLdapAuthentication()) {
-            return serverSettings.getSecurity().getLdap().getAdminGroup();
-        } else {
-            return DEFAULT_ACCESS_USER_ROLE;
-        }
-    }
 
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
@@ -138,4 +93,5 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .userDetailsService(localUserDetailsService)
                 .passwordEncoder(passwordEncoder);
     }
+
 }

--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/security/config/SharedSecurityConfiguration.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/security/config/SharedSecurityConfiguration.java
@@ -1,0 +1,66 @@
+package rocks.inspectit.ocelot.security.config;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import rocks.inspectit.ocelot.config.model.InspectitServerSettings;
+
+import static rocks.inspectit.ocelot.security.userdetails.LocalUserDetailsService.DEFAULT_ACCESS_USER_ROLE;
+
+/**
+ * Shared spring security configuration enabling authentication on all except excluded endpoints.
+ * <p>
+ * Sub-classes can extend the configuration.
+ */
+public class SharedSecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    @Autowired
+    @VisibleForTesting
+    InspectitServerSettings serverSettings;
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().antMatchers(
+                "/v2/api-docs",
+                "/configuration/**",
+                "/csrf",
+                "/",
+                "/ui/**",
+                "/actuator/**",
+                "/swagger*/**",
+                "/webjars/**",
+                "/api/v1/agent/configuration");
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+                .and()
+                .cors()
+
+                .and()
+                .authorizeRequests()
+                .anyRequest().hasRole(getAccessRole());
+    }
+
+    /**
+     * Returns the role name which is required by users to get access to the secured API endpoints.
+     * In case LDAP is not used, a constant role name is used, otherwise the configured role name of the LDAP settings is used.
+     *
+     * @return the role name to use
+     */
+    private String getAccessRole() {
+        if (serverSettings.getSecurity().isLdapAuthentication()) {
+            return serverSettings.getSecurity().getLdap().getAdminGroup();
+        } else {
+            return DEFAULT_ACCESS_USER_ROLE;
+        }
+    }
+
+}

--- a/components/inspectit-ocelot-configurationserver/src/main/resources/application.yml
+++ b/components/inspectit-ocelot-configurationserver/src/main/resources/application.yml
@@ -41,6 +41,11 @@ inspectit-config-server:
     # Whether LDAP authentication should be used
     ldap-authentication: false
 
+    # Enables the auth-proxy mode where principal is set in a specified request header
+    auth-proxy:
+      enabled: false
+      principal-request-header: AUTH
+
 # ACTUATOR PROPERTIES
 management:
   # Whether to enable or disable all endpoints by default.

--- a/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/security/config/AuthProxySecurityConfigurationIntTest.java
+++ b/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/security/config/AuthProxySecurityConfigurationIntTest.java
@@ -1,0 +1,70 @@
+package rocks.inspectit.ocelot.security.config;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.*;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.util.MultiValueMap;
+import rocks.inspectit.ocelot.IntegrationTestBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {
+        "inspectit-config-server.default-user.name=master",
+        "inspectit-config-server.security.auth-proxy.enabled=true",
+        "inspectit-config-server.security.auth-proxy.principal-request-header=someauthheader",
+})
+class AuthProxySecurityConfigurationIntTest extends IntegrationTestBase {
+
+    private static final String DIRECTORIES_URL = "/api/v1/directories";
+
+    @Nested
+    class AuthenticationActive {
+
+        @Test
+        void requestsWithoutAuthRejected() {
+            ResponseEntity<?> resp = rest.getForEntity(DIRECTORIES_URL, String.class);
+            assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+
+    @Nested
+    class PreAuthentication {
+
+        @Test
+        void invalidUserRejected() {
+            MultiValueMap<String, String> headers = new HttpHeaders();
+            headers.add("someauthheader", "someuser");
+
+            ResponseEntity<?> resp = rest
+                    .exchange(DIRECTORIES_URL, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+            assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        void invalidHeaderRejected() {
+            MultiValueMap<String, String> headers = new HttpHeaders();
+            headers.add("hackersheader", "master");
+
+            ResponseEntity<?> resp = rest
+                    .exchange(DIRECTORIES_URL, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+            assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        void correctAuthAccepted() {
+            MultiValueMap<String, String> headers = new HttpHeaders();
+            headers.add("someauthheader", "master");
+
+            ResponseEntity<?> resp = rest
+                    .exchange(DIRECTORIES_URL, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+            assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(resp.getBody()).isEqualTo("[]");
+        }
+    }
+
+}


### PR DESCRIPTION
So many things to discuss:

* First, there is security config switch now, if proxy auth is enabled, most of the existing stuff is dismissed:
   * There is only pre authentication, so no token, basic, ldap.. This is fine imo and has to be like this..
   * However if ldap is active we would use ldap to still retrieve the details about the user, thus correctly resolve the roles..
   * Some config is shared and this is extracted into a super class
* Works as simple as sending the username in the header, from there on we consult the active user service to resolve if user exists and what are his roles & grants..
* It works only if the username is passed to the existing user of course..

From the UI point (did not touch a thing until we agree):
* Login form is not needed any more when the auth proxy is on
  * So what we can do is try to fetch the token when the login form is shown in order to see if the token can be fetched without the auth (so using the proxy auth)
  * If this works everything else can be the same.. Token that is received would be only used on the UI, it would have no effect on the requests made as you can not auth with the token in this scenario
  * I guess this is how we can have minimum changes on the UI to be able to support both auth scenarios

However, it does not make sense to have a login form at all on the UI. We should have Oauth support and then we would not care what mode the backend is on. If it's default stuff, then the backend will present the login form and dispatch the oauth code on successful login that can be used to get the token. If it's auth proxy you would directly get the code.. The UI would not care.. However, this requires a lot of adaptation on the backend and the frontend.. I am not sure why this was not implemented like this in the first place?

In addition, the token should be used to access the api and the pre-auth or form auth only to retrieve the token. This is how correctly this should be split imo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/673)
<!-- Reviewable:end -->
