### PR TITLE
Closes #639 - Logback.xml in the configuration server JAR prevents custom log configurations

### DIFF
--- a/components/inspectit-ocelot-configurationserver/README.md
+++ b/components/inspectit-ocelot-configurationserver/README.md
@@ -4,8 +4,8 @@ This project contains the Ocelot configuration server.
 It's a standalone component based on Spring Boot.
 It can be build by `gradle bootJar` and started by `java -jar inspectit-ocelot-configurationserver-X.X.X.jar` or directly via gradle `gradle bootRun`.
 
-To use a custom logback config start Configuration Server like this `java -Dlogging.config=<PATH_TO_YOUR_LOGBACK_CONFIG> -jar inspectit-ocelot-configurationserver-X.X.X.jar`
-_Spring Boot ignores the default `-Dlogback.configurationFile` property_
+To use a custom logback configuration, you have to start the Configuration Server like this: `java -Dlogging.config=<PATH_TO_YOUR_LOGBACK_CONFIG> -jar inspectit-ocelot-configurationserver-X.X.X.jar`
+_Please note that Spring Boot ignores the default `-Dlogback.configurationFile` property!_
 
 It is used to manage and store agent configurations.
 The configurations can be fetched by Ocelot agents via a REST interface.

--- a/components/inspectit-ocelot-configurationserver/README.md
+++ b/components/inspectit-ocelot-configurationserver/README.md
@@ -4,9 +4,12 @@ This project contains the Ocelot configuration server.
 It's a standalone component based on Spring Boot.
 It can be build by `gradle bootJar` and started by `java -jar inspectit-ocelot-configurationserver-X.X.X.jar` or directly via gradle `gradle bootRun`.
 
+To use a custom logback config start Configuration Server like this `java -Dlogging.config=<PATH_TO_YOUR_LOGBACK_CONFIG> -jar inspectit-ocelot-configurationserver-X.X.X.jar`
+_Spring Boot ignores the default `-Dlogback.configurationFile` property_
+
 It is used to manage and store agent configurations.
 The configurations can be fetched by Ocelot agents via a REST interface.
 By default, the REST interface is exposed on port 8090.
 
 The application is using Swagger for API documentation and is also providing a Swagger UI.
-By default, the Swagger UI is available at: http://<HOST>:<PORT>/swagger-ui.html
+By default, the Swagger UI is available at: http://\<HOST\>:\<PORT\>/swagger-ui.html


### PR DESCRIPTION
No code changes needed. I just added an example to README

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/697)
<!-- Reviewable:end -->
