### PR TITLE
Fixed GeoLocationResolverIntTest of EUM server

### DIFF
--- a/components/inspectit-ocelot-eum-server/src/test/java/rocks/inspectit/oce/eum/server/utils/GeolocationResolverIntTest.java
+++ b/components/inspectit-ocelot-eum-server/src/test/java/rocks/inspectit/oce/eum/server/utils/GeolocationResolverIntTest.java
@@ -108,7 +108,7 @@ public class GeolocationResolverIntTest {
         Map<String, String> beacon = getBasicBeacon();
         beacon.put(BEACON_KEY_NAME, "12");
 
-        sendBeacon(beacon, "wrong-formatted-ip");
+        sendBeacon(beacon, "127.0.0.0.1");
 
         verify(beaconMetricManager).processBeacon(beaconCaptor.capture());
         assertThat(beaconCaptor.getValue().get(CountryCodeBeaconProcessor.TAG_COUNTRY_CODE)).isEmpty();


### PR DESCRIPTION
Fixed the `GeolocationResolverIntTest`, I am not sure what the problem was, but it seems that processing the beacon does not mean that the metrics are exposed immediately. Anyway, I think this is way better to test this functionality in the INT test, as old assertions were not really good imo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/731)
<!-- Reviewable:end -->
