### PR TITLE
Fixed wrong indentation in documentation example

### DIFF
--- a/inspectit-ocelot-documentation/docs/instrumentation/rules.md
+++ b/inspectit-ocelot-documentation/docs/instrumentation/rules.md
@@ -358,7 +358,7 @@ An example for the usage of a condition is given below:
       action: 'a_assign_value'
       constant-input:
         'value': 'My-Application'
-    only-if-null: 'application_name'
+      only-if-null: 'application_name'
 ```
 
 In this example we define an invocation to set the value of the data key `application_name`


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/732)
<!-- Reviewable:end -->
