### PR TITLE
Closes #782 - Added Endpoint for fetching agent configs without logging to agent status.

### DIFF
--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/rest/configuration/ConfigurationController.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/rest/configuration/ConfigurationController.java
@@ -1,0 +1,44 @@
+package rocks.inspectit.ocelot.rest.configuration;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import rocks.inspectit.ocelot.agentconfiguration.AgentConfiguration;
+import rocks.inspectit.ocelot.agentconfiguration.AgentConfigurationManager;
+import rocks.inspectit.ocelot.config.model.InspectitConfig;
+import rocks.inspectit.ocelot.rest.AbstractBaseController;
+
+import java.util.Map;
+
+@RestController
+public class ConfigurationController extends AbstractBaseController {
+
+    @Autowired
+    private AgentConfigurationManager configManager;
+
+    /**
+     * Returns the {@link InspectitConfig} for the agent with the given name without logging the access in the agent
+     * status.
+     * Uses text/plain as mime type to ensure that the configuration is presented nicely when opened in a browser
+     *
+     * @param attributes the attributes of the agents used to select the mapping
+     * @return The configuration mapped on the given agent name
+     */
+    @ApiOperation(value = "Fetch the Agent Configuration without logging the access.", notes = "Reads the configuration for the given agent and returns it as a yaml string." +
+            "Does not log the access in the agent status.")
+    @GetMapping(value = "configuration/agent-config", produces = "text/plain")
+    public ResponseEntity<String> fetchConfiguration(@ApiParam("The agent attributes used to select the correct mapping") @RequestParam Map<String, String> attributes) {
+        AgentConfiguration configuration = configManager.getConfiguration(attributes);
+        if (configuration == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        } else {
+            return ResponseEntity.ok()
+                    .body(configuration.getConfigYaml());
+        }
+    }
+}

--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/rest/configuration/ConfigurationController.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/rest/configuration/ConfigurationController.java
@@ -15,6 +15,9 @@ import rocks.inspectit.ocelot.rest.AbstractBaseController;
 
 import java.util.Map;
 
+/**
+ * Controller for endpoints related to configuration files.
+ */
 @RestController
 public class ConfigurationController extends AbstractBaseController {
 
@@ -31,7 +34,7 @@ public class ConfigurationController extends AbstractBaseController {
      */
     @ApiOperation(value = "Fetch the Agent Configuration without logging the access.", notes = "Reads the configuration for the given agent and returns it as a yaml string." +
             "Does not log the access in the agent status.")
-    @GetMapping(value = "configuration/agent-config", produces = "text/plain")
+    @GetMapping(value = "configuration/agent-configuration", produces = "text/plain")
     public ResponseEntity<String> fetchConfiguration(@ApiParam("The agent attributes used to select the correct mapping") @RequestParam Map<String, String> attributes) {
         AgentConfiguration configuration = configManager.getConfiguration(attributes);
         if (configuration == null) {

--- a/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/rest/configuration/ConfigurationControllerTest.java
+++ b/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/rest/configuration/ConfigurationControllerTest.java
@@ -1,0 +1,50 @@
+package rocks.inspectit.ocelot.rest.configuration;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import rocks.inspectit.ocelot.agentconfiguration.AgentConfigurationManager;
+import rocks.inspectit.ocelot.agentstatus.AgentStatus;
+import rocks.inspectit.ocelot.agentstatus.AgentStatusManager;
+import rocks.inspectit.ocelot.rest.agentstatus.AgentStatusController;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ConfigurationControllerTest {
+
+    @InjectMocks
+    ConfigurationController configurationController;
+
+    @Mock
+    AgentConfigurationManager agentConfigurationManager;
+
+    @Nested
+    public class FetchConfiguration {
+        @InjectMocks
+        AgentStatusController agentStatusController;
+
+        @Mock
+        AgentStatusManager agentStatusManager;
+
+        @Test
+        public void noLoggingEntryAdded() {
+            when(agentConfigurationManager.getConfiguration(any())).thenReturn(null);
+
+            Collection<AgentStatus> beforeRequest = agentStatusController.getAgentStatuses(null);
+            ResponseEntity<String> output = configurationController.fetchConfiguration(null);
+            Collection<AgentStatus> afterRequest = agentStatusController.getAgentStatuses(null);
+
+            assertThat(output.getBody()).isEqualTo(null);
+            assertThat(beforeRequest).isEqualTo(afterRequest);
+        }
+    }
+}


### PR DESCRIPTION
With the endpoint configuration/agent-config in the ConfigurationController agent configurations can now be fetched without the access being logged in the loading history.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/784)
<!-- Reviewable:end -->
