### PR TITLE
Fixed the configuration server's Flyway migration script version 2

### DIFF
--- a/components/inspectit-ocelot-configurationserver/src/main/resources/db/migration/V2__added_user_login_time.sql
+++ b/components/inspectit-ocelot-configurationserver/src/main/resources/db/migration/V2__added_user_login_time.sql
@@ -1,2 +1,2 @@
 ALTER TABLE user
-ADD last_login_time BIGINT;
+ADD last_login_time BIGINT NOT NULL DEFAULT(0);


### PR DESCRIPTION
The migration will add an empty column for the lastLoginTime. Unfortunately, `null` values are not allowed in this column leading to an exception when a user is loaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/789)
<!-- Reviewable:end -->
