### PR TITLE
Closes #821 - Added missing Netty SSL dependency for OC-Agent Trace Exporter

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/home/circleci/inspectit/repo/heapdump.bin
+# Ensure to adapt the netty version (inspectit-ocelot-core/build.gradle) when changing the OpenCensus version
 openCensusVersion=0.22.1.ocelot.1
 springVersion=2.1.1.RELEASE
 prometheusClientVersion=0.6.0
-#The boomerang version to ship with the EUM server
+# The boomerang version to ship with the EUM server
 boomerangVersion=1.650.0

--- a/inspectit-ocelot-core/build.gradle
+++ b/inspectit-ocelot-core/build.gradle
@@ -67,7 +67,13 @@ dependencies {
             "io.opencensus:opencensus-exporter-trace-zipkin:${openCensusVersion}",
             "io.opencensus:opencensus-exporter-trace-jaeger:${openCensusVersion}",
             "io.opencensus:opencensus-exporter-metrics-ocagent:${openCensusVersion}",
+
             "io.opencensus:opencensus-exporter-trace-ocagent:${openCensusVersion}",
+            // The following dependecy is required for the OC-exporter to work correctly and msut be matched against the grpc version
+            // See https://github.com/census-instrumentation/opencensus-java/blob/master/exporters/trace/ocagent/README.md
+            'io.netty:netty-tcnative-boringssl-static:2.0.20.Final',
+
+
             "rocks.inspectit:opencensus-influxdb-exporter:1.1",
             
             // bytecode manipulation

--- a/inspectit-ocelot-core/build.gradle
+++ b/inspectit-ocelot-core/build.gradle
@@ -69,7 +69,7 @@ dependencies {
             "io.opencensus:opencensus-exporter-metrics-ocagent:${openCensusVersion}",
 
             "io.opencensus:opencensus-exporter-trace-ocagent:${openCensusVersion}",
-            // The following dependecy is required for the OC-exporter to work correctly and msut be matched against the grpc version
+            // The following dependecy is required for the OC-exporter to work correctly and must be matched against the grpc version
             // See https://github.com/census-instrumentation/opencensus-java/blob/master/exporters/trace/ocagent/README.md
             'io.netty:netty-tcnative-boringssl-static:2.0.20.Final',
 


### PR DESCRIPTION
Closes #821

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/822)
<!-- Reviewable:end -->
