### PR TITLE
Closes #845 - Use LDAP-User mails when commiting if available

### DIFF
--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/config/model/InspectitServerSettings.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/config/model/InspectitServerSettings.java
@@ -31,7 +31,8 @@ public class InspectitServerSettings {
     /**
      * The mail suffix used for internal users.
      */
-    private String mailSuffix;
+    @Builder.Default
+    private String mailSuffix = "@inspectit.rocks";
 
     /**
      * The duration until an authentication token generated via /api/v1/account/token is valid.

--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/config/model/InspectitServerSettings.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/config/model/InspectitServerSettings.java
@@ -31,8 +31,7 @@ public class InspectitServerSettings {
     /**
      * The mail suffix used for internal users.
      */
-    @Builder.Default
-    private String mailSuffix = "@inspectit.rocks";
+    private String mailSuffix;
 
     /**
      * The duration until an authentication token generated via /api/v1/account/token is valid.

--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/config/model/InspectitServerSettings.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/config/model/InspectitServerSettings.java
@@ -29,6 +29,11 @@ public class InspectitServerSettings {
     private String workingDirectory;
 
     /**
+     * The mail suffix used for internal users.
+     */
+    private String mailSuffix;
+
+    /**
      * The duration until an authentication token generated via /api/v1/account/token is valid.
      * After the token has expired, a new one has to be acquired.
      */

--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/file/FileManager.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/file/FileManager.java
@@ -66,7 +66,7 @@ public class FileManager {
                 .writeLock(), workingDirectory);
 
         Supplier<Authentication> authenticationSupplier = () -> SecurityContextHolder.getContext().getAuthentication();
-        versioningManager = new VersioningManager(workingDirectory, authenticationSupplier, asyncPublisher);
+        versioningManager = new VersioningManager(workingDirectory, authenticationSupplier, asyncPublisher, settings);
         versioningManager.initialize();
 
         workingDirectoryAccessor = new AutoCommitWorkingDirectoryProxy(workingDirectoryLock.writeLock(), workingDirectoryAccessorImpl, versioningManager);
@@ -115,7 +115,6 @@ public class FileManager {
      * Returns the diff between the current live branch and the current workspace branch.
      *
      * @param includeContent whether the file difference (old and new content) is included
-     *
      * @return the diff between the live and workspace branch
      */
     public WorkspaceDiff getWorkspaceDiff(boolean includeContent) throws IOException, GitAPIException {

--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/file/FileManager.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/file/FileManager.java
@@ -66,7 +66,7 @@ public class FileManager {
                 .writeLock(), workingDirectory);
 
         Supplier<Authentication> authenticationSupplier = () -> SecurityContextHolder.getContext().getAuthentication();
-        versioningManager = new VersioningManager(workingDirectory, authenticationSupplier, asyncPublisher, settings);
+        versioningManager = new VersioningManager(workingDirectory, authenticationSupplier, asyncPublisher, settings.getMailSuffix());
         versioningManager.initialize();
 
         workingDirectoryAccessor = new AutoCommitWorkingDirectoryProxy(workingDirectoryLock.writeLock(), workingDirectoryAccessorImpl, versioningManager);
@@ -104,8 +104,8 @@ public class FileManager {
      */
     public RevisionAccess getWorkspaceRevision() {
         CachingRevisionAccess currentRev = versioningManager.getWorkspaceRevision();
-        if (cachedWorkspaceRevision == null
-                || !currentRev.getRevisionId().equals(cachedWorkspaceRevision.getRevisionId())) {
+        if (cachedWorkspaceRevision == null || !currentRev.getRevisionId()
+                .equals(cachedWorkspaceRevision.getRevisionId())) {
             cachedWorkspaceRevision = currentRev;
         }
         return cachedWorkspaceRevision;
@@ -115,6 +115,7 @@ public class FileManager {
      * Returns the diff between the current live branch and the current workspace branch.
      *
      * @param includeContent whether the file difference (old and new content) is included
+     *
      * @return the diff between the live and workspace branch
      */
     public WorkspaceDiff getWorkspaceDiff(boolean includeContent) throws IOException, GitAPIException {

--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/security/userdetails/CustomLdapUserDetailsMapper.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/security/userdetails/CustomLdapUserDetailsMapper.java
@@ -5,7 +5,6 @@ import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.ldap.userdetails.InetOrgPersonContextMapper;
-import org.springframework.security.ldap.userdetails.LdapUserDetailsMapper;
 import rocks.inspectit.ocelot.config.model.LdapRoleResolveSettings;
 import rocks.inspectit.ocelot.config.model.LdapSettings;
 import rocks.inspectit.ocelot.security.config.UserRoleConfiguration;
@@ -20,21 +19,18 @@ import java.util.stream.Collectors;
  * This class is used to populate user object with roles upon basic authentication when they are
  * authenticated by a ldap server.
  */
-public class CustomLdapUserDetailsMapper extends LdapUserDetailsMapper {
+public class CustomLdapUserDetailsMapper extends InetOrgPersonContextMapper {
 
     private LdapSettings settings;
 
-    private InetOrgPersonContextMapper inetOrgPersonContectMapper;
-
     public CustomLdapUserDetailsMapper(LdapSettings settings) {
         this.settings = settings;
-        inetOrgPersonContectMapper = new InetOrgPersonContextMapper();
     }
 
     @Override
     public UserDetails mapUserFromContext(DirContextOperations ctx, String username, Collection<? extends GrantedAuthority> authorities) {
         Collection<? extends GrantedAuthority> ocelotAuthorities = mapAuthorities(authorities);
-        return inetOrgPersonContectMapper.mapUserFromContext(ctx, username, ocelotAuthorities);
+        return super.mapUserFromContext(ctx, username, ocelotAuthorities);
     }
 
     /**
@@ -43,6 +39,7 @@ public class CustomLdapUserDetailsMapper extends LdapUserDetailsMapper {
      * matching authorities.
      *
      * @param authorities A List of GrantedAuthority-Objects that should be mapped.
+     *
      * @return The highest level of access role the user's authorities could be resolved to.
      */
     @VisibleForTesting
@@ -69,6 +66,7 @@ public class CustomLdapUserDetailsMapper extends LdapUserDetailsMapper {
      *
      * @param authorities A Collection containing GrantedAuthority objects.
      * @param roleList    The List of Strings the authorities are checked with.
+     *
      * @return Returns true if at least one element of authorities is contained in roleList or vice versa.
      */
     private boolean containsAuthority(Collection<? extends GrantedAuthority> authorities, List<String> roleList) {
@@ -84,6 +82,7 @@ public class CustomLdapUserDetailsMapper extends LdapUserDetailsMapper {
      * ensures backwards compatibility for the old configuration standard.
      *
      * @param authorities A collection of authorities the admin group should be contained in.
+     *
      * @return True if the given admin group is contained in the authorities. Otherwise false.
      */
     private boolean hasAdminGroup(Collection<? extends GrantedAuthority> authorities) {

--- a/components/inspectit-ocelot-configurationserver/src/main/resources/application.yml
+++ b/components/inspectit-ocelot-configurationserver/src/main/resources/application.yml
@@ -29,7 +29,7 @@ inspectit-config-server:
   # the expiration duration of JWT tokens
   token-lifespan: 60m
   # the e-mail suffix used for internal users
-  mail-suffix: @inspectit.rocks
+  mail-suffix: '@inspectit.rocks'
   # the default admin user
   default-user:
     name: admin

--- a/components/inspectit-ocelot-configurationserver/src/main/resources/application.yml
+++ b/components/inspectit-ocelot-configurationserver/src/main/resources/application.yml
@@ -28,6 +28,8 @@ inspectit-config-server:
   working-directory: working_directory
   # the expiration duration of JWT tokens
   token-lifespan: 60m
+  # the e-mail suffix used for internal users
+  mail-suffix: @inspectit.rocks
   # the default admin user
   default-user:
     name: admin

--- a/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/accessor/git/RevisionAccessIntTest.java
+++ b/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/accessor/git/RevisionAccessIntTest.java
@@ -8,8 +8,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
-import rocks.inspectit.ocelot.config.model.InspectitServerSettings;
-import rocks.inspectit.ocelot.config.model.SecuritySettings;
 import rocks.inspectit.ocelot.file.FileInfo;
 import rocks.inspectit.ocelot.file.FileTestBase;
 import rocks.inspectit.ocelot.file.versioning.VersioningManager;
@@ -49,12 +47,7 @@ class RevisionAccessIntTest extends FileTestBase {
         Authentication authentication = mock(Authentication.class);
         when(authentication.getName()).thenReturn("user");
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
-        InspectitServerSettings inspectitServerSettings = mock(InspectitServerSettings.class);
-        SecuritySettings securitySettings = mock(SecuritySettings.class);
-        when(securitySettings.isLdapAuthentication()).thenReturn(false);
-        when(inspectitServerSettings.getSecurity()).thenReturn(securitySettings);
-        when(inspectitServerSettings.getMailSuffix()).thenReturn("foo.com");
-        versioningManager = new VersioningManager(tempDirectory, () -> authentication, eventPublisher, inspectitServerSettings);
+        versioningManager = new VersioningManager(tempDirectory, () -> authentication, eventPublisher, "@test.com");
 
         setupRepository();
 
@@ -246,8 +239,7 @@ class RevisionAccessIntTest extends FileTestBase {
 
         @Test
         public void illegalPath() {
-            assertThatExceptionOfType(IllegalArgumentException.class)
-                    .isThrownBy(() -> revision.readConfigurationFile("../untracked.yml"));
+            assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> revision.readConfigurationFile("../untracked.yml"));
         }
     }
 
@@ -284,11 +276,9 @@ class RevisionAccessIntTest extends FileTestBase {
 
         @Test
         public void illegalPath() {
-            assertThatExceptionOfType(IllegalArgumentException.class)
-                    .isThrownBy(() -> revision.configurationFileExists("../untracked.yml"));
+            assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> revision.configurationFileExists("../untracked.yml"));
         }
     }
-
 
     @Nested
     class ConfigurationFileIsDirectory {
@@ -316,8 +306,7 @@ class RevisionAccessIntTest extends FileTestBase {
 
         @Test
         public void illegalPath() {
-            assertThatExceptionOfType(IllegalArgumentException.class)
-                    .isThrownBy(() -> revision.configurationFileExists(".."));
+            assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> revision.configurationFileExists(".."));
         }
     }
 }

--- a/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/accessor/git/RevisionAccessIntTest.java
+++ b/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/accessor/git/RevisionAccessIntTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
+import rocks.inspectit.ocelot.config.model.InspectitServerSettings;
+import rocks.inspectit.ocelot.config.model.SecuritySettings;
 import rocks.inspectit.ocelot.file.FileInfo;
 import rocks.inspectit.ocelot.file.FileTestBase;
 import rocks.inspectit.ocelot.file.versioning.VersioningManager;
@@ -47,7 +49,12 @@ class RevisionAccessIntTest extends FileTestBase {
         Authentication authentication = mock(Authentication.class);
         when(authentication.getName()).thenReturn("user");
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
-        versioningManager = new VersioningManager(tempDirectory, () -> authentication, eventPublisher);
+        InspectitServerSettings inspectitServerSettings = mock(InspectitServerSettings.class);
+        SecuritySettings securitySettings = mock(SecuritySettings.class);
+        when(securitySettings.isLdapAuthentication()).thenReturn(false);
+        when(inspectitServerSettings.getSecurity()).thenReturn(securitySettings);
+        when(inspectitServerSettings.getMailSuffix()).thenReturn("foo.com");
+        versioningManager = new VersioningManager(tempDirectory, () -> authentication, eventPublisher, inspectitServerSettings);
 
         setupRepository();
 

--- a/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/accessor/workingdirectory/AutoCommitWorkingDirectoryProxyIntTest.java
+++ b/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/accessor/workingdirectory/AutoCommitWorkingDirectoryProxyIntTest.java
@@ -58,7 +58,7 @@ class AutoCommitWorkingDirectoryProxyIntTest extends FileTestBase {
         when(securitySettings.isLdapAuthentication()).thenReturn(false);
         when(inspectitServerSettings.getSecurity()).thenReturn(securitySettings);
         when(inspectitServerSettings.getMailSuffix()).thenReturn("foo.com");
-        versioningManager = new VersioningManager(tempDirectory, () -> authentication, eventPublisher, inspectitServerSettings);
+        versioningManager = new VersioningManager(tempDirectory, () -> authentication, eventPublisher, "@test.com");
         versioningManager.initialize();
 
         accessor = new AutoCommitWorkingDirectoryProxy(writeLock, workingDirectoryAccessor, versioningManager);

--- a/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/accessor/workingdirectory/AutoCommitWorkingDirectoryProxyIntTest.java
+++ b/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/accessor/workingdirectory/AutoCommitWorkingDirectoryProxyIntTest.java
@@ -8,8 +8,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
-import rocks.inspectit.ocelot.config.model.InspectitServerSettings;
-import rocks.inspectit.ocelot.config.model.SecuritySettings;
 import rocks.inspectit.ocelot.file.FileTestBase;
 import rocks.inspectit.ocelot.file.versioning.VersioningManager;
 
@@ -53,11 +51,6 @@ class AutoCommitWorkingDirectoryProxyIntTest extends FileTestBase {
 
         Authentication authentication = mock(Authentication.class);
         when(authentication.getName()).thenReturn("user");
-        InspectitServerSettings inspectitServerSettings = mock(InspectitServerSettings.class);
-        SecuritySettings securitySettings = mock(SecuritySettings.class);
-        when(securitySettings.isLdapAuthentication()).thenReturn(false);
-        when(inspectitServerSettings.getSecurity()).thenReturn(securitySettings);
-        when(inspectitServerSettings.getMailSuffix()).thenReturn("foo.com");
         versioningManager = new VersioningManager(tempDirectory, () -> authentication, eventPublisher, "@test.com");
         versioningManager.initialize();
 

--- a/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/accessor/workingdirectory/AutoCommitWorkingDirectoryProxyIntTest.java
+++ b/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/accessor/workingdirectory/AutoCommitWorkingDirectoryProxyIntTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
+import rocks.inspectit.ocelot.config.model.InspectitServerSettings;
+import rocks.inspectit.ocelot.config.model.SecuritySettings;
 import rocks.inspectit.ocelot.file.FileTestBase;
 import rocks.inspectit.ocelot.file.versioning.VersioningManager;
 
@@ -51,7 +53,12 @@ class AutoCommitWorkingDirectoryProxyIntTest extends FileTestBase {
 
         Authentication authentication = mock(Authentication.class);
         when(authentication.getName()).thenReturn("user");
-        versioningManager = new VersioningManager(tempDirectory, () -> authentication, eventPublisher);
+        InspectitServerSettings inspectitServerSettings = mock(InspectitServerSettings.class);
+        SecuritySettings securitySettings = mock(SecuritySettings.class);
+        when(securitySettings.isLdapAuthentication()).thenReturn(false);
+        when(inspectitServerSettings.getSecurity()).thenReturn(securitySettings);
+        when(inspectitServerSettings.getMailSuffix()).thenReturn("foo.com");
+        versioningManager = new VersioningManager(tempDirectory, () -> authentication, eventPublisher, inspectitServerSettings);
         versioningManager.initialize();
 
         accessor = new AutoCommitWorkingDirectoryProxy(writeLock, workingDirectoryAccessor, versioningManager);

--- a/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/versioning/VersioningManagerTest.java
+++ b/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/versioning/VersioningManagerTest.java
@@ -14,7 +14,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.ldap.userdetails.InetOrgPerson;
 import org.springframework.test.util.ReflectionTestUtils;
-import rocks.inspectit.ocelot.config.model.InspectitServerSettings;
 import rocks.inspectit.ocelot.error.exceptions.SelfPromotionNotAllowedException;
 import rocks.inspectit.ocelot.events.WorkspaceChangedEvent;
 import rocks.inspectit.ocelot.file.FileTestBase;
@@ -47,8 +46,6 @@ class VersioningManagerTest extends FileTestBase {
     private Authentication authentication;
 
     private ApplicationEventPublisher eventPublisher;
-
-    private InspectitServerSettings inspectitServerSettings;
 
     @BeforeEach
     public void beforeEach() throws IOException {

--- a/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/versioning/VersioningManagerTest.java
+++ b/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/versioning/VersioningManagerTest.java
@@ -15,7 +15,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.ldap.userdetails.InetOrgPerson;
 import org.springframework.test.util.ReflectionTestUtils;
 import rocks.inspectit.ocelot.config.model.InspectitServerSettings;
-import rocks.inspectit.ocelot.config.model.SecuritySettings;
 import rocks.inspectit.ocelot.error.exceptions.SelfPromotionNotAllowedException;
 import rocks.inspectit.ocelot.events.WorkspaceChangedEvent;
 import rocks.inspectit.ocelot.file.FileTestBase;
@@ -63,13 +62,8 @@ class VersioningManagerTest extends FileTestBase {
         authentication = mock(Authentication.class);
         when(authentication.getName()).thenReturn("user");
         eventPublisher = mock(ApplicationEventPublisher.class);
-        inspectitServerSettings = mock(InspectitServerSettings.class);
-        when(inspectitServerSettings.getMailSuffix()).thenReturn("test.com");
-        SecuritySettings securitySettings = mock(SecuritySettings.class);
-        when(securitySettings.isLdapAuthentication()).thenReturn(false);
-        when(inspectitServerSettings.getSecurity()).thenReturn(securitySettings);
 
-        versioningManager = new VersioningManager(tempDirectory, () -> authentication, eventPublisher, inspectitServerSettings);
+        versioningManager = new VersioningManager(tempDirectory, () -> authentication, eventPublisher, "test.com");
 
         System.out.println("Test data in: " + tempDirectory.toString());
     }
@@ -246,8 +240,7 @@ class VersioningManagerTest extends FileTestBase {
             Git git = (Git) ReflectionTestUtils.getField(versioningManager, "git");
             git.checkout().setName(Branch.LIVE.getBranchName()).call();
 
-            assertThatIllegalStateException()
-                    .isThrownBy(() -> versioningManager.commitAllChanges("test"))
+            assertThatIllegalStateException().isThrownBy(() -> versioningManager.commitAllChanges("test"))
                     .withMessage("The workspace branch is currently not checked out. Ensure your working directory is in a correct state!");
 
             assertThat(versioningManager.getCommitCount()).isOne();
@@ -397,14 +390,19 @@ class VersioningManagerTest extends FileTestBase {
 
             WorkspaceDiff result = versioningManager.getWorkspaceDiffWithoutContent();
 
-            assertThat(result.getEntries()).containsExactlyInAnyOrder(
-                    SimpleDiffEntry.builder().file("/file_added.yml").type(DiffEntry.ChangeType.ADD)
-                            .authors(Collections.singletonList("user")).build(),
-                    SimpleDiffEntry.builder().file("/file_modified.yml").type(DiffEntry.ChangeType.MODIFY)
-                            .authors(Collections.singletonList("user")).build(),
-                    SimpleDiffEntry.builder().file("/file_removed.yml").type(DiffEntry.ChangeType.DELETE)
-                            .authors(Collections.singletonList("user")).build()
-            );
+            assertThat(result.getEntries()).containsExactlyInAnyOrder(SimpleDiffEntry.builder()
+                    .file("/file_added.yml")
+                    .type(DiffEntry.ChangeType.ADD)
+                    .authors(Collections.singletonList("user"))
+                    .build(), SimpleDiffEntry.builder()
+                    .file("/file_modified.yml")
+                    .type(DiffEntry.ChangeType.MODIFY)
+                    .authors(Collections.singletonList("user"))
+                    .build(), SimpleDiffEntry.builder()
+                    .file("/file_removed.yml")
+                    .type(DiffEntry.ChangeType.DELETE)
+                    .authors(Collections.singletonList("user"))
+                    .build());
             assertThat(result.getLiveCommitId()).isNotEqualTo(result.getWorkspaceCommitId());
         }
 
@@ -421,27 +419,23 @@ class VersioningManagerTest extends FileTestBase {
 
             WorkspaceDiff result = versioningManager.getWorkspaceDiff(true);
 
-            assertThat(result.getEntries()).containsExactlyInAnyOrder(
-                    SimpleDiffEntry.builder()
-                            .file("/file_added.yml")
-                            .type(DiffEntry.ChangeType.ADD)
-                            .newContent("")
-                            .authors(Collections.singletonList("user"))
-                            .build(),
-                    SimpleDiffEntry.builder()
-                            .file("/file_modified.yml")
-                            .type(DiffEntry.ChangeType.MODIFY)
-                            .oldContent("")
-                            .newContent("new content")
-                            .authors(Collections.singletonList("user"))
-                            .build(),
-                    SimpleDiffEntry.builder()
-                            .file("/file_removed.yml")
-                            .type(DiffEntry.ChangeType.DELETE)
-                            .oldContent("content")
-                            .authors(Collections.singletonList("user"))
-                            .build()
-            );
+            assertThat(result.getEntries()).containsExactlyInAnyOrder(SimpleDiffEntry.builder()
+                    .file("/file_added.yml")
+                    .type(DiffEntry.ChangeType.ADD)
+                    .newContent("")
+                    .authors(Collections.singletonList("user"))
+                    .build(), SimpleDiffEntry.builder()
+                    .file("/file_modified.yml")
+                    .type(DiffEntry.ChangeType.MODIFY)
+                    .oldContent("")
+                    .newContent("new content")
+                    .authors(Collections.singletonList("user"))
+                    .build(), SimpleDiffEntry.builder()
+                    .file("/file_removed.yml")
+                    .type(DiffEntry.ChangeType.DELETE)
+                    .oldContent("content")
+                    .authors(Collections.singletonList("user"))
+                    .build());
             assertThat(result.getLiveCommitId()).isNotEqualTo(result.getWorkspaceCommitId());
         }
 
@@ -463,27 +457,23 @@ class VersioningManagerTest extends FileTestBase {
             WorkspaceDiff resultFirst = versioningManager.getWorkspaceDiff(true, liveId, workspaceId);
             WorkspaceDiff resultSecond = versioningManager.getWorkspaceDiff(true, liveId, latestWorkspaceId);
 
-            assertThat(resultFirst.getEntries()).containsExactlyInAnyOrder(
-                    SimpleDiffEntry.builder()
-                            .file("/file_modified.yml")
-                            .type(DiffEntry.ChangeType.MODIFY)
-                            .oldContent("")
-                            .newContent("new content")
-                            .authors(Collections.singletonList("user"))
-                            .build()
-            );
+            assertThat(resultFirst.getEntries()).containsExactlyInAnyOrder(SimpleDiffEntry.builder()
+                    .file("/file_modified.yml")
+                    .type(DiffEntry.ChangeType.MODIFY)
+                    .oldContent("")
+                    .newContent("new content")
+                    .authors(Collections.singletonList("user"))
+                    .build());
             assertThat(resultFirst.getLiveCommitId()).isEqualTo(liveId.name());
             assertThat(resultFirst.getWorkspaceCommitId()).isEqualTo(workspaceId.name());
 
-            assertThat(resultSecond.getEntries()).containsExactlyInAnyOrder(
-                    SimpleDiffEntry.builder()
-                            .file("/file_modified.yml")
-                            .type(DiffEntry.ChangeType.MODIFY)
-                            .oldContent("")
-                            .newContent("another content")
-                            .authors(Collections.singletonList("user"))
-                            .build()
-            );
+            assertThat(resultSecond.getEntries()).containsExactlyInAnyOrder(SimpleDiffEntry.builder()
+                    .file("/file_modified.yml")
+                    .type(DiffEntry.ChangeType.MODIFY)
+                    .oldContent("")
+                    .newContent("another content")
+                    .authors(Collections.singletonList("user"))
+                    .build());
             assertThat(resultSecond.getLiveCommitId()).isEqualTo(liveId.name());
             assertThat(resultSecond.getWorkspaceCommitId()).isEqualTo(latestWorkspaceId.name());
         }
@@ -509,11 +499,7 @@ class VersioningManagerTest extends FileTestBase {
             ConfigurationPromotion promotion = new ConfigurationPromotion();
             promotion.setLiveCommitId(liveId);
             promotion.setWorkspaceCommitId(workspaceId);
-            promotion.setFiles(Arrays.asList(
-                    "/file_added.yml",
-                    "/file_modified.yml",
-                    "/file_removed.yml"
-            ));
+            promotion.setFiles(Arrays.asList("/file_added.yml", "/file_modified.yml", "/file_removed.yml"));
 
             versioningManager.promoteConfiguration(promotion, true);
 
@@ -539,19 +525,17 @@ class VersioningManagerTest extends FileTestBase {
             ConfigurationPromotion promotion = new ConfigurationPromotion();
             promotion.setLiveCommitId(liveId);
             promotion.setWorkspaceCommitId(workspaceId);
-            promotion.setFiles(Arrays.asList(
-                    "/file_modified.yml",
-                    "/file_removed.yml"
-            ));
+            promotion.setFiles(Arrays.asList("/file_modified.yml", "/file_removed.yml"));
 
             versioningManager.promoteConfiguration(promotion, true);
 
             WorkspaceDiff diff = versioningManager.getWorkspaceDiffWithoutContent();
 
-            assertThat(diff.getEntries()).containsExactlyInAnyOrder(
-                    SimpleDiffEntry.builder().file("/file_added.yml").type(DiffEntry.ChangeType.ADD)
-                            .authors(Collections.singletonList("user")).build()
-            );
+            assertThat(diff.getEntries()).containsExactlyInAnyOrder(SimpleDiffEntry.builder()
+                    .file("/file_added.yml")
+                    .type(DiffEntry.ChangeType.ADD)
+                    .authors(Collections.singletonList("user"))
+                    .build());
         }
 
         @Test
@@ -571,9 +555,7 @@ class VersioningManagerTest extends FileTestBase {
             ConfigurationPromotion promotion = new ConfigurationPromotion();
             promotion.setLiveCommitId(liveId);
             promotion.setWorkspaceCommitId(workspaceId);
-            promotion.setFiles(Arrays.asList(
-                    "/file_modified.yml"
-            ));
+            promotion.setFiles(Arrays.asList("/file_modified.yml"));
 
             // first promotion
             versioningManager.promoteConfiguration(promotion, true);
@@ -588,9 +570,7 @@ class VersioningManagerTest extends FileTestBase {
             promotion = new ConfigurationPromotion();
             promotion.setLiveCommitId(liveId);
             promotion.setWorkspaceCommitId(workspaceId);
-            promotion.setFiles(Arrays.asList(
-                    "/file_modified.yml"
-            ));
+            promotion.setFiles(Arrays.asList("/file_modified.yml"));
 
             // second promotion
             versioningManager.promoteConfiguration(promotion, true);
@@ -598,12 +578,15 @@ class VersioningManagerTest extends FileTestBase {
             // diff
             WorkspaceDiff diff = versioningManager.getWorkspaceDiffWithoutContent();
 
-            assertThat(diff.getEntries()).containsExactlyInAnyOrder(
-                    SimpleDiffEntry.builder().file("/file_added.yml").type(DiffEntry.ChangeType.ADD)
-                            .authors(Collections.singletonList("user")).build(),
-                    SimpleDiffEntry.builder().file("/file_removed.yml").type(DiffEntry.ChangeType.DELETE)
-                            .authors(Collections.singletonList("user")).build()
-            );
+            assertThat(diff.getEntries()).containsExactlyInAnyOrder(SimpleDiffEntry.builder()
+                    .file("/file_added.yml")
+                    .type(DiffEntry.ChangeType.ADD)
+                    .authors(Collections.singletonList("user"))
+                    .build(), SimpleDiffEntry.builder()
+                    .file("/file_removed.yml")
+                    .type(DiffEntry.ChangeType.DELETE)
+                    .authors(Collections.singletonList("user"))
+                    .build());
         }
 
         @Test
@@ -623,21 +606,16 @@ class VersioningManagerTest extends FileTestBase {
             ConfigurationPromotion promotion = new ConfigurationPromotion();
             promotion.setLiveCommitId(liveId);
             promotion.setWorkspaceCommitId(workspaceId);
-            promotion.setFiles(Arrays.asList(
-                    "/file_modified.yml"
-            ));
+            promotion.setFiles(Arrays.asList("/file_modified.yml"));
 
             versioningManager.promoteConfiguration(promotion, true);
 
             ConfigurationPromotion secondPromotion = new ConfigurationPromotion();
             secondPromotion.setLiveCommitId(liveId);
             secondPromotion.setWorkspaceCommitId(workspaceId);
-            secondPromotion.setFiles(Arrays.asList(
-                    "/file_added.yml"
-            ));
+            secondPromotion.setFiles(Arrays.asList("/file_added.yml"));
 
-            assertThatExceptionOfType(RuntimeException.class)
-                    .isThrownBy(() -> versioningManager.promoteConfiguration(secondPromotion, true))
+            assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> versioningManager.promoteConfiguration(secondPromotion, true))
                     .withMessage("Live branch has been modified. The provided promotion definition is out of sync.");
         }
 
@@ -654,9 +632,7 @@ class VersioningManagerTest extends FileTestBase {
             ConfigurationPromotion promotion = new ConfigurationPromotion();
             promotion.setLiveCommitId(liveId);
             promotion.setWorkspaceCommitId(workspaceId);
-            promotion.setFiles(Arrays.asList(
-                    "/file_modified.yml"
-            ));
+            promotion.setFiles(Arrays.asList("/file_modified.yml"));
 
             createTestFiles(AbstractFileAccessor.CONFIGURATION_FILES_SUBFOLDER + "/file_modified.yml=content_B");
             versioningManager.commitAllChanges("commit");
@@ -666,10 +642,11 @@ class VersioningManagerTest extends FileTestBase {
             // diff live -> workspace
             WorkspaceDiff diff = versioningManager.getWorkspaceDiffWithoutContent();
 
-            assertThat(diff.getEntries()).containsExactlyInAnyOrder(
-                    SimpleDiffEntry.builder().file("/file_modified.yml").type(DiffEntry.ChangeType.MODIFY)
-                            .authors(Collections.singletonList("user")).build()
-            );
+            assertThat(diff.getEntries()).containsExactlyInAnyOrder(SimpleDiffEntry.builder()
+                    .file("/file_modified.yml")
+                    .type(DiffEntry.ChangeType.MODIFY)
+                    .authors(Collections.singletonList("user"))
+                    .build());
             assertThat(versioningManager.getLiveRevision()
                     .readConfigurationFile("file_modified.yml")).hasValue("content_A");
             assertThat(versioningManager.getWorkspaceRevision()
@@ -689,9 +666,7 @@ class VersioningManagerTest extends FileTestBase {
             ConfigurationPromotion promotion = new ConfigurationPromotion();
             promotion.setLiveCommitId(liveId);
             promotion.setWorkspaceCommitId(workspaceId);
-            promotion.setFiles(Arrays.asList(
-                    "/file_modified.yml"
-            ));
+            promotion.setFiles(Arrays.asList("/file_modified.yml"));
 
             createTestFiles(AbstractFileAccessor.CONFIGURATION_FILES_SUBFOLDER + "/file_modified.yml=content_B");
             versioningManager.commitAllChanges("commit");
@@ -718,17 +693,13 @@ class VersioningManagerTest extends FileTestBase {
             ConfigurationPromotion promotion = new ConfigurationPromotion();
             promotion.setLiveCommitId(liveId);
             promotion.setWorkspaceCommitId(workspaceId);
-            promotion.setFiles(Arrays.asList(
-                    "/file_modified.yml"
-            ));
+            promotion.setFiles(Arrays.asList("/file_modified.yml"));
 
             RevisionAccess live = versioningManager.getLiveRevision();
 
-            assertThatThrownBy(() -> versioningManager.promoteConfiguration(promotion, false))
-                    .isInstanceOf(SelfPromotionNotAllowedException.class);
+            assertThatThrownBy(() -> versioningManager.promoteConfiguration(promotion, false)).isInstanceOf(SelfPromotionNotAllowedException.class);
 
-            assertThat(versioningManager.getLiveRevision().getRevisionId())
-                    .isEqualTo(live.getRevisionId());
+            assertThat(versioningManager.getLiveRevision().getRevisionId()).isEqualTo(live.getRevisionId());
         }
     }
 
@@ -758,21 +729,21 @@ class VersioningManagerTest extends FileTestBase {
         @Test
         void systemUserOnSystemOperationUsed() {
             VersioningManager vm = new VersioningManager(Paths.get(""), () -> null, (event) -> {
-            }, inspectitServerSettings);
+            }, "@test.com");
             assertThat(vm.getCurrentAuthor()).isEqualTo(VersioningManager.GIT_SYSTEM_AUTHOR);
         }
 
         @Test
         void activeUserUsed() {
             VersioningManager vm = new VersioningManager(Paths.get(""), () -> authentication, (event) -> {
-            }, inspectitServerSettings);
+            }, "@test.com");
             assertThat(vm.getCurrentAuthor().getName()).isEqualTo(authentication.getName());
         }
 
         @Test
         void mailCreatedFromConfig() {
             VersioningManager vm = new VersioningManager(Paths.get(""), () -> authentication, (event) -> {
-            }, inspectitServerSettings);
+            }, "@test.com");
             assertThat(vm.getCurrentAuthor().getEmailAddress()).isEqualTo(authentication.getName() + "@" + "test.com");
         }
 
@@ -781,12 +752,10 @@ class VersioningManagerTest extends FileTestBase {
             InetOrgPerson mockInetOrgPerson = mock(InetOrgPerson.class);
             when(mockInetOrgPerson.getMail()).thenReturn("foo@bar.com");
             when(authentication.getPrincipal()).thenReturn(mockInetOrgPerson);
-            SecuritySettings mockSecuritySettings = mock(SecuritySettings.class);
-            when(mockSecuritySettings.isLdapAuthentication()).thenReturn(true);
-            when(inspectitServerSettings.getSecurity()).thenReturn(mockSecuritySettings);
 
             VersioningManager vm = new VersioningManager(Paths.get(""), () -> authentication, (event) -> {
-            }, inspectitServerSettings);
+            }, "@test.com");
+
             assertThat(vm.getCurrentAuthor().getEmailAddress()).isEqualTo("foo@bar.com");
         }
     }
@@ -812,21 +781,14 @@ class VersioningManagerTest extends FileTestBase {
             createTestFiles(AbstractFileAccessor.CONFIGURATION_FILES_SUBFOLDER + "/c1_file_a.yml=content");
             doReturn("user_a").when(authentication).getName();
             versioningManager.commitAllChanges("new commit");
-            promote(
-                    "/c0_file_a.yml",
-                    "/c0_file_b.yml",
-                    "/c1_file_a.yml"
-            );
+            promote("/c0_file_a.yml", "/c0_file_b.yml", "/c1_file_a.yml");
 
             Files.delete(tempDirectory.resolve(AbstractFileAccessor.CONFIGURATION_FILES_SUBFOLDER + "/c0_file_b.yml"));
             createTestFiles(AbstractFileAccessor.CONFIGURATION_FILES_SUBFOLDER + "/c1_file_a.yml=newFileContent");
 
             doReturn("user_b").when(authentication).getName();
             versioningManager.commitAllChanges("new commit");
-            promote(
-                    "/c0_file_b.yml",
-                    "/c1_file_a.yml"
-            );
+            promote("/c0_file_b.yml", "/c1_file_a.yml");
         }
 
         @Test
@@ -842,12 +804,11 @@ class VersioningManagerTest extends FileTestBase {
                     .type(DiffEntry.ChangeType.ADD)
                     .build();
 
-            versioningManager.fillInAuthors(diff,
-                    versioningManager.getLatestCommit(Branch.LIVE).get().getId(),
-                    versioningManager.getLatestCommit(Branch.WORKSPACE).get().getId());
+            versioningManager.fillInAuthors(diff, versioningManager.getLatestCommit(Branch.LIVE)
+                    .get()
+                    .getId(), versioningManager.getLatestCommit(Branch.WORKSPACE).get().getId());
 
-            assertThat(diff.getAuthors())
-                    .containsExactlyInAnyOrder("creating_user");
+            assertThat(diff.getAuthors()).containsExactlyInAnyOrder("creating_user");
         }
 
         @Test
@@ -874,12 +835,11 @@ class VersioningManagerTest extends FileTestBase {
                     .type(DiffEntry.ChangeType.ADD)
                     .build();
 
-            versioningManager.fillInAuthors(diff,
-                    versioningManager.getLatestCommit(Branch.LIVE).get().getId(),
-                    versioningManager.getLatestCommit(Branch.WORKSPACE).get().getId());
+            versioningManager.fillInAuthors(diff, versioningManager.getLatestCommit(Branch.LIVE)
+                    .get()
+                    .getId(), versioningManager.getLatestCommit(Branch.WORKSPACE).get().getId());
 
-            assertThat(diff.getAuthors())
-                    .containsExactlyInAnyOrder("creating_user", "editing_user");
+            assertThat(diff.getAuthors()).containsExactlyInAnyOrder("creating_user", "editing_user");
         }
 
         @Test
@@ -918,12 +878,11 @@ class VersioningManagerTest extends FileTestBase {
                     .type(DiffEntry.ChangeType.MODIFY)
                     .build();
 
-            versioningManager.fillInAuthors(diff,
-                    versioningManager.getLatestCommit(Branch.LIVE).get().getId(),
-                    versioningManager.getLatestCommit(Branch.WORKSPACE).get().getId());
+            versioningManager.fillInAuthors(diff, versioningManager.getLatestCommit(Branch.LIVE)
+                    .get()
+                    .getId(), versioningManager.getLatestCommit(Branch.WORKSPACE).get().getId());
 
-            assertThat(diff.getAuthors())
-                    .containsExactlyInAnyOrder("creating_user", "second_editing_user");
+            assertThat(diff.getAuthors()).containsExactlyInAnyOrder("creating_user", "second_editing_user");
         }
 
         @Test
@@ -953,12 +912,11 @@ class VersioningManagerTest extends FileTestBase {
                     .type(DiffEntry.ChangeType.MODIFY)
                     .build();
 
-            versioningManager.fillInAuthors(diff,
-                    versioningManager.getLatestCommit(Branch.LIVE).get().getId(),
-                    versioningManager.getLatestCommit(Branch.WORKSPACE).get().getId());
+            versioningManager.fillInAuthors(diff, versioningManager.getLatestCommit(Branch.LIVE)
+                    .get()
+                    .getId(), versioningManager.getLatestCommit(Branch.WORKSPACE).get().getId());
 
-            assertThat(diff.getAuthors())
-                    .containsExactlyInAnyOrder("last_editing_user");
+            assertThat(diff.getAuthors()).containsExactlyInAnyOrder("last_editing_user");
         }
 
         @Test
@@ -990,12 +948,11 @@ class VersioningManagerTest extends FileTestBase {
                     .type(DiffEntry.ChangeType.DELETE)
                     .build();
 
-            versioningManager.fillInAuthors(diff,
-                    versioningManager.getLatestCommit(Branch.LIVE).get().getId(),
-                    versioningManager.getLatestCommit(Branch.WORKSPACE).get().getId());
+            versioningManager.fillInAuthors(diff, versioningManager.getLatestCommit(Branch.LIVE)
+                    .get()
+                    .getId(), versioningManager.getLatestCommit(Branch.WORKSPACE).get().getId());
 
-            assertThat(diff.getAuthors())
-                    .containsExactlyInAnyOrder("deleting_user");
+            assertThat(diff.getAuthors()).containsExactlyInAnyOrder("deleting_user");
         }
 
         @Test
@@ -1022,12 +979,11 @@ class VersioningManagerTest extends FileTestBase {
                     .type(DiffEntry.ChangeType.DELETE)
                     .build();
 
-            versioningManager.fillInAuthors(diff,
-                    versioningManager.getLatestCommit(Branch.LIVE).get().getId(),
-                    versioningManager.getLatestCommit(Branch.WORKSPACE).get().getId());
+            versioningManager.fillInAuthors(diff, versioningManager.getLatestCommit(Branch.LIVE)
+                    .get()
+                    .getId(), versioningManager.getLatestCommit(Branch.WORKSPACE).get().getId());
 
-            assertThat(diff.getAuthors())
-                    .containsExactlyInAnyOrder("deleting_user");
+            assertThat(diff.getAuthors()).containsExactlyInAnyOrder("deleting_user");
         }
     }
 }

--- a/inspectit-ocelot-documentation/docs/config-server/managing-configurations.md
+++ b/inspectit-ocelot-documentation/docs/config-server/managing-configurations.md
@@ -54,3 +54,16 @@ When this setting is enabled, users with promotion rights will no longer be able
 :::note
 This restriction is only applied to non-admin users! Users with admin rights will still be able to promote their own changes.
 :::
+
+## Git-Authors
+Every change has an author consisting of the login and an e-mail address of the user who made the change. For 
+ldap-users the login and e-mail address of the ldap account is used. 
+<br>
+For internal users however, an e-mail address is generated. This address consists of the user's login and an e-mail
+suffix. The default suffix is `@inspectit.rocks`.
+<br>
+You can provide a custom mail suffix in the following settings: 
+```YAML
+inspectit-config-server:
+  mail-suffix: @my_mail.com
+```


### PR DESCRIPTION
The mail suffix for internal users can be changed in the config at inspectit-config-server.mail-suffix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/856)
<!-- Reviewable:end -->
