### PR TITLE
Closes #920 - Kapacitor view starts scrolling when there are too many items in the tree view

### DIFF
--- a/components/inspectit-ocelot-configurationserver-ui/src/components/views/alerting/rules/AlertingRulesView.js
+++ b/components/inspectit-ocelot-configurationserver-ui/src/components/views/alerting/rules/AlertingRulesView.js
@@ -16,9 +16,9 @@ const AlertingRulesView = ({ updateDate, topics, rules, templates, onRefresh }) 
     <>
       <style jsx>{`
         .this {
-          height: 100%;
           display: flex;
           flex-grow: 1;
+          overflow: hidden;
         }
       `}</style>
 

--- a/components/inspectit-ocelot-configurationserver-ui/src/components/views/alerting/topics/AlertingChannelsView.js
+++ b/components/inspectit-ocelot-configurationserver-ui/src/components/views/alerting/topics/AlertingChannelsView.js
@@ -64,9 +64,9 @@ const AlertingChannelsView = ({ topics, updateDate, onRefresh }) => {
     <div className="this">
       <style jsx>{`
         .this {
-          height: 100%;
           display: flex;
           flex-grow: 1;
+          overflow: hidden;
         }
       `}</style>
       <AlertingChannelsTreeContainer

--- a/components/inspectit-ocelot-configurationserver-ui/src/components/views/alerting/topics/tree/AlertingChannelsTree.js
+++ b/components/inspectit-ocelot-configurationserver-ui/src/components/views/alerting/topics/tree/AlertingChannelsTree.js
@@ -57,7 +57,8 @@ const AlertingChannelsTree = ({ topicNodes, selection, onSelectionChanged }) => 
     <div className="this">
       <style jsx>{`
         .this {
-          height: 100%;
+          overflow: auto;
+          flex-grow: 1;
           display: flex;
           flex-direction: column;
           border-right: 1px solid #ddd;


### PR DESCRIPTION
closes #920

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/925)
<!-- Reviewable:end -->
