### PR TITLE
Changes behaviour of "invalid value log" in the rt.bmr beacon processor

### DIFF
--- a/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/beacon/processor/CsvExpanderBeaconProcessor.java
+++ b/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/beacon/processor/CsvExpanderBeaconProcessor.java
@@ -45,7 +45,9 @@ public class CsvExpanderBeaconProcessor implements BeaconProcessor {
                     isSum = true;
                     beacon = beacon.merge(Collections.singletonMap(resultKey, attributes[i]));
                 } catch (Exception e) {
-                    log.error("Error parsing the value <'{}'>: invalid number.", attributes[i]);
+                    if (!String.valueOf(attributes[i]).isEmpty()) {
+                        log.debug("Error parsing the value <'{}'>: invalid number.", attributes[i]);
+                    }
                 }
             }
             if (isSum) {

--- a/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/beacon/processor/CsvExpanderBeaconProcessor.java
+++ b/components/inspectit-ocelot-eum-server/src/main/java/rocks/inspectit/oce/eum/server/beacon/processor/CsvExpanderBeaconProcessor.java
@@ -40,13 +40,13 @@ public class CsvExpanderBeaconProcessor implements BeaconProcessor {
             for (int i = 0; i < attributes.length; i++) {
                 String resultKey = ATTRIBUTE_KEY + "." + i;
 
-                try {
-                    sum += Integer.parseInt(attributes[i]);
-                    isSum = true;
-                    beacon = beacon.merge(Collections.singletonMap(resultKey, attributes[i]));
-                } catch (Exception e) {
-                    if (!String.valueOf(attributes[i]).isEmpty()) {
-                        log.debug("Error parsing the value <'{}'>: invalid number.", attributes[i]);
+                if (!StringUtils.isBlank(attributes[i])) {
+                    try {
+                        sum += Integer.parseInt(attributes[i]);
+                        isSum = true;
+                        beacon = beacon.merge(Collections.singletonMap(resultKey, attributes[i]));
+                    } catch (Exception e) {
+                        log.trace("Error parsing the value <'{}'>: invalid number.", attributes[i]);
                     }
                 }
             }

--- a/components/inspectit-ocelot-eum-server/src/test/java/rocks/inspectit/oce/eum/server/beacon/processor/CsvExpanderBeaconProcessorTest.java
+++ b/components/inspectit-ocelot-eum-server/src/test/java/rocks/inspectit/oce/eum/server/beacon/processor/CsvExpanderBeaconProcessorTest.java
@@ -101,5 +101,14 @@ class CsvExpanderBeaconProcessorTest {
 
             assertThat(result.toMap()).containsOnly(entry("rt.bmr", "123,bar,321"), entry("rt.bmr.0", "123"), entry("rt.bmr.2", "321"), entry("rt.bmr.sum", "444"));
         }
+
+        @Test
+        public void rtBmrMultipleValuesWithTwoInvalidValues() {
+            Beacon beacon = Beacon.of(Collections.singletonMap("rt.bmr", "123,bar,321,foo"));
+
+            Beacon result = processor.process(beacon);
+
+            assertThat(result.toMap()).containsOnly(entry("rt.bmr", "123,bar,321,foo"), entry("rt.bmr.0", "123"), entry("rt.bmr.2", "321"), entry("rt.bmr.sum", "444"));
+        }
     }
 }


### PR DESCRIPTION
If a value of the rt.bmr beacon is not a number or empty, the log message is printed continuously. 
- Now the Log message is printed only as result of invalid numbers (empty values will be skipped)
- The log message is printed as "trace" log level

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/1023)
<!-- Reviewable:end -->
