### PR TITLE
Allow disabling console log on start-up

### DIFF
--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/logging/logback/LogbackInitializer.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/logging/logback/LogbackInitializer.java
@@ -6,6 +6,7 @@ import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.spi.FilterReply;
 import ch.qos.logback.core.util.StatusPrinter;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
@@ -15,6 +16,7 @@ import rocks.inspectit.ocelot.config.model.logging.LoggingSettings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Main logback initializer. Method {@link #initLogging(InspectitConfig)} can be called whenever inspectIT configuration is changed in order to update the logging settings.
@@ -49,15 +51,19 @@ public class LogbackInitializer {
     static final String INSPECTIT_LOG_FILE_PATTERN = "INSPECTIT_LOG_FILE_PATTERN";
 
     /**
-     * Allow disabling the console log before the log system is initialized
+     * Allow disabling the console log before the log system is initialized.
      */
     static final String INSPECTIT_LOGGING_CONSOLE_ENABLED = "INSPECTIT_LOGGING_CONSOLE_ENABLED";
 
     // flags for the filters
-    static boolean consoleEnabled = Boolean.parseBoolean(System.getenv(INSPECTIT_LOGGING_CONSOLE_ENABLED) == null ? "true" : System.getenv(INSPECTIT_LOGGING_CONSOLE_ENABLED));
+    static boolean consoleEnabled = isConsoleInitiallyEnabled();
+
     static boolean fileEnabled = true;
+
     static boolean selfMonitoringEnabled = true;
 
+    @VisibleForTesting
+    static Function<String, String> getEnvironment = System::getenv;
 
     public static void initDefaultLogging() {
         initLogging(null);
@@ -85,6 +91,20 @@ public class LogbackInitializer {
             // StatusPrinter will handle this
         }
         StatusPrinter.printInCaseOfErrorsOrWarnings(context);
+    }
+
+    @VisibleForTesting
+    static boolean isConsoleInitiallyEnabled() {
+        String enabledFlag = System.getProperty(INSPECTIT_LOGGING_CONSOLE_ENABLED);
+        if (enabledFlag == null) {
+            enabledFlag = getEnvironment.apply(INSPECTIT_LOGGING_CONSOLE_ENABLED);
+        }
+
+        if (enabledFlag == null) {
+            return true;
+        } else {
+            return Boolean.parseBoolean(enabledFlag);
+        }
     }
 
     private static InputStream getConfigFileInputStream(InspectitConfig config) {
@@ -148,12 +168,12 @@ public class LogbackInitializer {
         }
     }
 
-
     /**
      * Sets system property if value is not null and report if the set was done.
      *
      * @param name  property name
      * @param value property value
+     *
      * @return if set was done
      */
     private static boolean setSystemProperty(String name, String value) {
@@ -168,6 +188,7 @@ public class LogbackInitializer {
      * Clears system property and report if the clear was done.
      *
      * @param name property name
+     *
      * @return true if property was set and then cleared
      */
     private static boolean clearSystemProperty(String name) {

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/logging/logback/LogbackInitializer.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/logging/logback/LogbackInitializer.java
@@ -55,15 +55,16 @@ public class LogbackInitializer {
      */
     static final String INSPECTIT_LOGGING_CONSOLE_ENABLED = "INSPECTIT_LOGGING_CONSOLE_ENABLED";
 
-    // flags for the filters
-    static boolean consoleEnabled = isConsoleInitiallyEnabled();
-
-    static boolean fileEnabled = true;
-
-    static boolean selfMonitoringEnabled = true;
-
+    /**
+     * {@link #consoleEnabled} is depending on this function, thus, the field order is important.
+     */
     @VisibleForTesting
     static Function<String, String> getEnvironment = System::getenv;
+
+    // flags for the filters
+    static boolean consoleEnabled = isConsoleInitiallyEnabled();
+    static boolean fileEnabled = true;
+    static boolean selfMonitoringEnabled = true;
 
     public static void initDefaultLogging() {
         initLogging(null);

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/logging/logback/LogbackInitializer.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/logging/logback/LogbackInitializer.java
@@ -48,8 +48,13 @@ public class LogbackInitializer {
      */
     static final String INSPECTIT_LOG_FILE_PATTERN = "INSPECTIT_LOG_FILE_PATTERN";
 
+    /**
+     * Allow disabling the console log before the log system is initialized
+     */
+    static final String INSPECTIT_LOGGING_CONSOLE_ENABLED = "INSPECTIT_LOGGING_CONSOLE_ENABLED";
+
     // flags for the filters
-    static boolean consoleEnabled = true;
+    static boolean consoleEnabled = Boolean.parseBoolean(System.getenv(INSPECTIT_LOGGING_CONSOLE_ENABLED) == null ? "true" : System.getenv(INSPECTIT_LOGGING_CONSOLE_ENABLED));
     static boolean fileEnabled = true;
     static boolean selfMonitoringEnabled = true;
 

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/logging/logback/LogbackInitializerTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/logging/logback/LogbackInitializerTest.java
@@ -1,0 +1,96 @@
+package rocks.inspectit.ocelot.core.logging.logback;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static rocks.inspectit.ocelot.core.logging.logback.LogbackInitializer.INSPECTIT_LOGGING_CONSOLE_ENABLED;
+
+@ExtendWith(MockitoExtension.class)
+public class LogbackInitializerTest {
+
+    @Nested
+    class IsConsoleInitiallyEnabled {
+
+        @AfterEach
+        public void afterEach() {
+            System.clearProperty(INSPECTIT_LOGGING_CONSOLE_ENABLED);
+            LogbackInitializer.getEnvironment = System::getenv;
+        }
+
+        @Test
+        public void withoutSystemProperty() {
+            boolean result = LogbackInitializer.isConsoleInitiallyEnabled();
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        public void systemPropertyIsTrue() {
+            System.setProperty(INSPECTIT_LOGGING_CONSOLE_ENABLED, "true");
+
+            boolean result = LogbackInitializer.isConsoleInitiallyEnabled();
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        public void systemPropertyIsFalse() {
+            System.setProperty(INSPECTIT_LOGGING_CONSOLE_ENABLED, "false");
+
+            boolean result = LogbackInitializer.isConsoleInitiallyEnabled();
+
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        public void systemPropertyIsInvalid() {
+            System.setProperty(INSPECTIT_LOGGING_CONSOLE_ENABLED, "no-boolean");
+
+            boolean result = LogbackInitializer.isConsoleInitiallyEnabled();
+
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        public void environmentIsTrue() {
+            LogbackInitializer.getEnvironment = envKey -> "true";
+
+            boolean result = LogbackInitializer.isConsoleInitiallyEnabled();
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        public void environmentIsFalse() {
+            LogbackInitializer.getEnvironment = envKey -> "false";
+
+            boolean result = LogbackInitializer.isConsoleInitiallyEnabled();
+
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        public void environmentIsInvalid() {
+            LogbackInitializer.getEnvironment = envKey -> "no-boolean";
+
+            boolean result = LogbackInitializer.isConsoleInitiallyEnabled();
+
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        public void testPropertyEnvPriority() {
+            System.setProperty(INSPECTIT_LOGGING_CONSOLE_ENABLED, "false");
+            LogbackInitializer.getEnvironment = envKey -> "true";
+
+            boolean result = LogbackInitializer.isConsoleInitiallyEnabled();
+
+            assertThat(result).isFalse();
+        }
+    }
+
+}


### PR DESCRIPTION
Allow disabling the console log before the log system is initialized

This is required to disable the log on console for:

`
2021-05-30 21:13:44,503 INFO 143 --- [inspectIT] [ Thread-0] rocks.inspectit.ocelot.core.AgentImpl : Starting inspectIT Ocelot Agent...
2021-05-30 21:13:44,504 INFO 144 --- [inspectIT] [ Thread-0] rocks.inspectit.ocelot.core.AgentImpl : Version: SNAPSHOT
2021-05-30 21:13:44,504 INFO 144 --- [inspectIT] [ Thread-0] rocks.inspectit.ocelot.core.AgentImpl : Build Date: Sun May 30 20:52:21 AEST 2021
2021-05-30 21:13:44,505 INFO 145 --- [inspectIT] [ Thread-0] rocks.inspectit.ocelot.core.AgentImpl : OpenCensus was loaded in inspectIT classloader
2021-05-30 21:13:45,035 INFO 675 --- [inspectIT] [ Thread-0] r.i.o.core.config.InspectitEnvironment : Registered Configuration Sources:
2021-05-30 21:13:45,035 INFO 675 --- [inspectIT] [ Thread-0] r.i.o.core.config.InspectitEnvironment : systemProperties
2021-05-30 21:13:45,036 INFO 676 --- [inspectIT] [ Thread-0] r.i.o.core.config.InspectitEnvironment : systemEnvironment
2021-05-30 21:13:45,036 INFO 676 --- [inspectIT] [ Thread-0] r.i.o.core.config.InspectitEnvironment : inspectitDefaults
2021-05-30 21:13:45,036 INFO 676 --- [inspectIT] [ Thread-0] r.i.o.core.config.InspectitEnvironment : inspectitEnvironment
`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/1095)
<!-- Reviewable:end -->
