### PR TITLE
Closes #1108 - Introduce an option to derive the agent-command url based on the HTTP config URL

### DIFF
--- a/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/command/AgentCommandSettings.java
+++ b/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/command/AgentCommandSettings.java
@@ -26,6 +26,11 @@ public class AgentCommandSettings {
     private boolean deriveFromHttpConfigUrl = false;
 
     /**
+     * Path which is used for the agent command URL in case it is derived from the HTTP configuration URL
+     */
+    private String agentCommandPath;
+
+    /**
      * The timeout duration used for requests  when the agent is in discovery mode. Defining how long the agent will wait for
      * new commands.
      */

--- a/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/command/AgentCommandSettings.java
+++ b/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/command/AgentCommandSettings.java
@@ -21,6 +21,11 @@ public class AgentCommandSettings {
     private URL url;
 
     /**
+     * Whether the agent commands URL should be derived from the HTTP configuration URL.
+     */
+    private boolean deriveFromHttpConfigUrl = false;
+
+    /**
      * The timeout duration used for requests  when the agent is in discovery mode. Defining how long the agent will wait for
      * new commands.
      */

--- a/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/basics.yml
+++ b/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/basics.yml
@@ -106,7 +106,9 @@ inspectit:
     # whether agent commands are enabled or not
     enabled: false
     # the URL for fetching agent commands - e.g.: http://localhost:8090/api/v1/agent/command
-    url: http://localhost:8090/api/v1/agent/command
+    url:
+    # whether the agent commands URL should be derived from the HTTP configuration URL
+    derive-from-http-config-url: false
     # the timeout duration used when the agent is in discovery mode. Defining how long the agent
     # will wait for new commands.
     live-socket-timeout: 30s

--- a/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/basics.yml
+++ b/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/basics.yml
@@ -109,6 +109,8 @@ inspectit:
     url:
     # whether the agent commands URL should be derived from the HTTP configuration URL
     derive-from-http-config-url: false
+    # path which is used for the agent command URL in case it is derived from the HTTP configuration URL
+    agent-command-path: "/api/v1/agent/command"
     # the timeout duration used when the agent is in discovery mode. Defining how long the agent
     # will wait for new commands.
     live-socket-timeout: 30s

--- a/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/core.yml
+++ b/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/core.yml
@@ -35,7 +35,7 @@ inspectit:
       use-inspectit-protection-domain: true
 
       # defines whether orphan action classes are recycled or new classes should be injected instead
-      recyclingOldActionClasses: true
+      recycling-old-action-classes: true
 
     data:
       # used for storing a received remote span id

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/command/AgentCommandService.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/command/AgentCommandService.java
@@ -58,11 +58,11 @@ public class AgentCommandService extends DynamicallyActivatableService implement
 
     @Override
     protected boolean doEnable(InspectitConfig configuration) {
-        log.info("Starting agent command polling service.");
-
         try {
             URI commandUri = getCommandUri(configuration);
             commandFetcher.setCommandUri(commandUri);
+
+            log.info("Starting agent command polling service with URL: {}", commandUri);
         } catch (Exception e) {
             log.error("Could not enable the agent command polling service.", e);
             return false;

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/command/AgentCommandService.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/command/AgentCommandService.java
@@ -113,7 +113,7 @@ public class AgentCommandService extends DynamicallyActivatableService implement
                 urlBase += ":" + port;
             }
 
-            return URI.create(urlBase + "/api/v1/agent/command");
+            return URI.create(urlBase + settings.getAgentCommandPath());
         } else {
             return settings.getUrl().toURI();
         }

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/command/AgentCommandService.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/command/AgentCommandService.java
@@ -1,5 +1,6 @@
 package rocks.inspectit.ocelot.core.command;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -7,6 +8,9 @@ import rocks.inspectit.ocelot.config.model.InspectitConfig;
 import rocks.inspectit.ocelot.config.model.command.AgentCommandSettings;
 import rocks.inspectit.ocelot.core.service.DynamicallyActivatableService;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -21,11 +25,11 @@ public class AgentCommandService extends DynamicallyActivatableService implement
     @Autowired
     private ScheduledExecutorService executor;
 
-    /**
-     * The state of the used HTTP property source configuration.
-     */
     @Autowired
     private CommandHandler commandHandler;
+
+    @Autowired
+    private HttpCommandFetcher commandFetcher;
 
     /**
      * The scheduled task.
@@ -38,12 +42,31 @@ public class AgentCommandService extends DynamicallyActivatableService implement
 
     @Override
     protected boolean checkEnabledForConfig(InspectitConfig configuration) {
-        return configuration.getAgentCommands().isEnabled();
+        AgentCommandSettings settings = configuration.getAgentCommands();
+        // the feature has to be enabled
+        if (!settings.isEnabled()) {
+            return false;
+        }
+
+        // enable the feature if the url is based on the HTTP config URL OR the url is specified directly
+        if (settings.isDeriveFromHttpConfigUrl()) {
+            return true;
+        } else {
+            return settings.getUrl() != null;
+        }
     }
 
     @Override
     protected boolean doEnable(InspectitConfig configuration) {
         log.info("Starting agent command polling service.");
+
+        try {
+            URI commandUri = getCommandUri(configuration);
+            commandFetcher.setCommandUri(commandUri);
+        } catch (Exception e) {
+            log.error("Could not enable the agent command polling service.", e);
+            return false;
+        }
 
         AgentCommandSettings settings = configuration.getAgentCommands();
         long pollingIntervalMs = settings.getPollingInterval().toMillis();
@@ -70,6 +93,29 @@ public class AgentCommandService extends DynamicallyActivatableService implement
             commandHandler.nextCommand();
         } catch (Exception exception) {
             log.error("Error while fetching agent command.", exception);
+        }
+    }
+
+    @VisibleForTesting
+    URI getCommandUri(InspectitConfig configuration) throws URISyntaxException {
+        AgentCommandSettings settings = configuration.getAgentCommands();
+
+        if (settings.isDeriveFromHttpConfigUrl()) {
+            URL url = configuration.getConfig().getHttp().getUrl();
+            if (url == null) {
+                throw new IllegalStateException("The URL cannot derived from the HTTP configuration URL because it is null.");
+            }
+
+            String urlBase = String.format("%s://%s", url.getProtocol(), url.getHost());
+
+            int port = url.getPort();
+            if (port != -1) {
+                urlBase += ":" + port;
+            }
+
+            return URI.create(urlBase + "/api/v1/agent/command");
+        } else {
+            return settings.getUrl().toURI();
         }
     }
 }

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/command/HttpCommandFetcher.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/command/HttpCommandFetcher.java
@@ -2,6 +2,7 @@ package rocks.inspectit.ocelot.core.command;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -11,10 +12,13 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import rocks.inspectit.ocelot.commons.models.command.Command;
 import rocks.inspectit.ocelot.commons.models.command.response.CommandResponse;
+import rocks.inspectit.ocelot.config.model.InspectitConfig;
 import rocks.inspectit.ocelot.config.model.command.AgentCommandSettings;
+import rocks.inspectit.ocelot.core.config.InspectitConfigChangedEvent;
 import rocks.inspectit.ocelot.core.config.InspectitEnvironment;
 
 import java.io.UnsupportedEncodingException;
@@ -49,6 +53,12 @@ public class HttpCommandFetcher {
      * Http client used in the live mode (longer timeouts).
      */
     private HttpClient liveHttpClient;
+
+    /**
+     * The URI for fetching commands.
+     */
+    @Setter
+    private URI commandUri;
 
     /**
      * Returns the {@link HttpClient} which is used for fetching commands.
@@ -87,12 +97,10 @@ public class HttpCommandFetcher {
      *
      * @return returns null if any error occurred before/while sending the request.
      */
-    public HttpResponse fetchCommand(CommandResponse commandResponse, boolean waitForCommand)  {
+    public HttpResponse fetchCommand(CommandResponse commandResponse, boolean waitForCommand) {
         HttpPost httpPost;
         try {
-            AgentCommandSettings settings = environment.getCurrentConfig().getAgentCommands();
-
-            URIBuilder uriBuilder = new URIBuilder(settings.getUrl().toURI());
+            URIBuilder uriBuilder = new URIBuilder(commandUri);
             if (waitForCommand) {
                 uriBuilder.addParameter("wait-for-command", "true");
             }
@@ -123,7 +131,7 @@ public class HttpCommandFetcher {
         try {
             return getHttpClient(waitForCommand).execute(httpPost);
         } catch (Exception e) {
-            log.error("An error occurred while fetching a new command: " + e.getMessage());
+            log.error("An error occurred while fetching an agent command.", e);
         } finally {
             httpPost.releaseConnection();
         }

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/command/AgentCommandServiceTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/command/AgentCommandServiceTest.java
@@ -3,21 +3,24 @@ package rocks.inspectit.ocelot.core.command;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Answers;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import rocks.inspectit.ocelot.config.model.InspectitConfig;
 import rocks.inspectit.ocelot.config.model.config.ConfigSettings;
 import rocks.inspectit.ocelot.config.model.config.HttpConfigSettings;
 
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.time.Duration;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -35,20 +38,30 @@ public class AgentCommandServiceTest {
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private InspectitConfig configuration;
 
+    @Mock
+    private HttpCommandFetcher commandFetcher;
+
     @Nested
     public class DoEnable {
 
+        @Captor
+        private ArgumentCaptor<URI>  uriCaptor;
+
         @Test
-        public void successfullyEnabled() {
+        public void successfullyEnabled() throws MalformedURLException {
             when(configuration.getAgentCommands().getPollingInterval()).thenReturn(Duration.ofSeconds(1));
+            lenient().when(configuration.getAgentCommands().getUrl()).thenReturn(new URL("http://inspectit.rocks"));
+            when(configuration.getConfig().getHttp().getUrl()).thenReturn(new URL("http://example.org/api/endpoint"));
+            when(configuration.getAgentCommands().isDeriveFromHttpConfigUrl()).thenReturn(true);
 
             boolean result = service.doEnable(configuration);
 
-            assertTrue(result);
             verify(executor).scheduleWithFixedDelay(service, 1000, 1000, TimeUnit.MILLISECONDS);
-            verifyNoMoreInteractions(executor);
+            verify(commandFetcher).setCommandUri(uriCaptor.capture());
+            verifyNoMoreInteractions(executor, commandFetcher);
+            assertThat(result).isTrue();
+            assertThat(uriCaptor.getValue().toString()).isEqualTo("http://example.org/api/v1/agent/command");
         }
-
     }
 
     @Nested
@@ -58,12 +71,14 @@ public class AgentCommandServiceTest {
         public void notEnabled() {
             boolean result = service.doDisable();
 
-            assertTrue(result);
+            assertThat(result).isTrue();
+            verifyZeroInteractions(commandFetcher);
         }
 
         @Test
-        public void isEnabled() {
+        public void isEnabled() throws MalformedURLException {
             when(configuration.getAgentCommands().getPollingInterval()).thenReturn(Duration.ofSeconds(1));
+            when(configuration.getAgentCommands().getUrl()).thenReturn(new URL("http://example.org"));
             ScheduledFuture futureMock = mock(ScheduledFuture.class);
             when(executor.scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(futureMock);
 
@@ -71,9 +86,61 @@ public class AgentCommandServiceTest {
 
             boolean result = service.doDisable();
 
-            assertTrue(result);
+            assertThat(result).isTrue();
             verify(futureMock).cancel(true);
+            verify(commandFetcher).setCommandUri(any());
+            verifyNoMoreInteractions(commandFetcher);
         }
     }
 
+    @Nested
+    public class GetCommandUri {
+
+        @Test
+        public void validCommandUrl() throws Exception {
+            when(configuration.getAgentCommands().getUrl()).thenReturn(new URL("http://example.org:8090/api"));
+
+            URI result = service.getCommandUri(configuration);
+
+            assertThat(result.toString()).isEqualTo("http://example.org:8090/api");
+        }
+
+        @Test
+        public void deriveUrlWithoutConfigUrl() {
+            when(configuration.getAgentCommands().isDeriveFromHttpConfigUrl()).thenReturn(true);
+
+            assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> service.getCommandUri(configuration))
+                    .withMessage("The URL cannot derived from the HTTP configuration URL because it is null.");
+        }
+
+        @Test
+        public void deriveUrl() throws Exception {
+            when(configuration.getConfig()
+                    .getHttp()
+                    .getUrl()).thenReturn(new URL("http://example.org:8090/api/endpoint"));
+            when(configuration.getAgentCommands().isDeriveFromHttpConfigUrl()).thenReturn(true);
+            URI result = service.getCommandUri(configuration);
+
+            assertThat(result.toString()).isEqualTo("http://example.org:8090/api/v1/agent/command");
+        }
+
+        @Test
+        public void deriveUrlWithoutPort() throws Exception {
+            when(configuration.getConfig().getHttp().getUrl()).thenReturn(new URL("http://example.org/api/endpoint"));
+            when(configuration.getAgentCommands().isDeriveFromHttpConfigUrl()).thenReturn(true);
+            URI result = service.getCommandUri(configuration);
+
+            assertThat(result.toString()).isEqualTo("http://example.org/api/v1/agent/command");
+        }
+
+        @Test
+        public void verifyPrioritization() throws Exception {
+            lenient().when(configuration.getAgentCommands().getUrl()).thenReturn(new URL("http://example.org"));
+            when(configuration.getConfig().getHttp().getUrl()).thenReturn(new URL("http://example.org/api/endpoint"));
+            when(configuration.getAgentCommands().isDeriveFromHttpConfigUrl()).thenReturn(true);
+            URI result = service.getCommandUri(configuration);
+
+            assertThat(result.toString()).isEqualTo("http://example.org/api/v1/agent/command");
+        }
+    }
 }

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/command/AgentCommandServiceTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/command/AgentCommandServiceTest.java
@@ -1,5 +1,6 @@
 package rocks.inspectit.ocelot.core.command;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -119,6 +120,7 @@ public class AgentCommandServiceTest {
                     .getHttp()
                     .getUrl()).thenReturn(new URL("http://example.org:8090/api/endpoint"));
             when(configuration.getAgentCommands().isDeriveFromHttpConfigUrl()).thenReturn(true);
+            when(configuration.getAgentCommands().getAgentCommandPath()).thenReturn("/api/v1/agent/command");
             URI result = service.getCommandUri(configuration);
 
             assertThat(result.toString()).isEqualTo("http://example.org:8090/api/v1/agent/command");
@@ -128,9 +130,10 @@ public class AgentCommandServiceTest {
         public void deriveUrlWithoutPort() throws Exception {
             when(configuration.getConfig().getHttp().getUrl()).thenReturn(new URL("http://example.org/api/endpoint"));
             when(configuration.getAgentCommands().isDeriveFromHttpConfigUrl()).thenReturn(true);
+            when(configuration.getAgentCommands().getAgentCommandPath()).thenReturn("/api/command");
             URI result = service.getCommandUri(configuration);
 
-            assertThat(result.toString()).isEqualTo("http://example.org/api/v1/agent/command");
+            assertThat(result.toString()).isEqualTo("http://example.org/api/command");
         }
 
         @Test
@@ -138,9 +141,10 @@ public class AgentCommandServiceTest {
             lenient().when(configuration.getAgentCommands().getUrl()).thenReturn(new URL("http://example.org"));
             when(configuration.getConfig().getHttp().getUrl()).thenReturn(new URL("http://example.org/api/endpoint"));
             when(configuration.getAgentCommands().isDeriveFromHttpConfigUrl()).thenReturn(true);
+            when(configuration.getAgentCommands().getAgentCommandPath()).thenReturn("/api/command");
             URI result = service.getCommandUri(configuration);
 
-            assertThat(result.toString()).isEqualTo("http://example.org/api/v1/agent/command");
+            assertThat(result.toString()).isEqualTo("http://example.org/api/command");
         }
     }
 }

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/command/AgentCommandServiceTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/command/AgentCommandServiceTest.java
@@ -54,6 +54,7 @@ public class AgentCommandServiceTest {
             lenient().when(configuration.getAgentCommands().getUrl()).thenReturn(new URL("http://inspectit.rocks"));
             when(configuration.getConfig().getHttp().getUrl()).thenReturn(new URL("http://example.org/api/endpoint"));
             when(configuration.getAgentCommands().isDeriveFromHttpConfigUrl()).thenReturn(true);
+            when(configuration.getAgentCommands().getAgentCommandPath()).thenReturn("/api/v1/agent/command");
 
             boolean result = service.doEnable(configuration);
 

--- a/inspectit-ocelot-documentation/docs/breaking-changes/breaking-changes.md
+++ b/inspectit-ocelot-documentation/docs/breaking-changes/breaking-changes.md
@@ -3,7 +3,17 @@ id: Breaking Changes
 title: Breaking Changes
 ---
 
-## Breaking changes in 1.9
+## Breaking changes in 1.10.1
+
+There are no breaking changes for version 1.10.1.
+
+
+## Breaking changes in 1.10.0
+
+There are no breaking changes for version 1.10.0.
+
+
+## Breaking changes in 1.9.0
 
 ### Upgraded OpenTelemetry of the EUM Server
 

--- a/inspectit-ocelot-documentation/docs/configuration/agent-command-configuration.md
+++ b/inspectit-ocelot-documentation/docs/configuration/agent-command-configuration.md
@@ -91,6 +91,16 @@ This setting takes the URL defined under `inspectit.config.http.url` as a basis.
 This setting has a higher priority than manually specifying the URL.
 If an agent command URL is configured and the `derive-from-http-config-url` option is enabled, the URL is ignored if it is possible to derive the agent command URL based on the HTTP configuration URL.
 
+To generate the agent command URL, only the information regarding protocol, host and port is used from the URL of the HTTP configuration. 
+By default, `/api/v1/agent/command` is used as the path of the URL.
+However, this can be adjusted using the following configuration, for example in the case that the configuration server is operated behind a reverse proxy and the URLs are not accessible under their actual name:
+
+```YAML
+inspectit:
+  agent-commands:
+    agent-command-path: "/proxy/command"
+```
+
 ### Additional Configuration Options
 
 The agent command feature can be more precisely configured to the needs with the following optional parameters which are defined bellow the property `inspectit.agent-commands`:

--- a/inspectit-ocelot-documentation/docs/configuration/agent-command-configuration.md
+++ b/inspectit-ocelot-documentation/docs/configuration/agent-command-configuration.md
@@ -91,3 +91,13 @@ This setting takes the URL defined under `inspectit.config.http.url` as a basis.
 This setting has a higher priority than manually specifying the URL.
 If an agent command URL is configured and the `derive-from-http-config-url` option is enabled, the URL is ignored if it is possible to derive the agent command URL based on the HTTP configuration URL.
 
+### Additional Configuration Options
+
+The agent command feature can be more precisely configured to the needs with the following optional parameters which are defined bellow the property `inspectit.agent-commands`:
+
+| Property | Default Value | Description |
+| --- | --- | --- |
+| <nobr>`live-socket-timeout`</nobr> | `30s` | The timeout duration used when the agent is in discovery mode. Defining how long the agent will wait for new commands. |
+| `socket-timeout` | `5s` | The timeout duration used for requests when the agent is in normal mode. |
+| `polling-interval` | `15s` | The used interval for polling agent commands. |
+| `live-mode-duration` | `2m` | How long the agent will staying in the live mode, before falling back to the normal mode. |

--- a/inspectit-ocelot-documentation/docs/configuration/agent-command-configuration.md
+++ b/inspectit-ocelot-documentation/docs/configuration/agent-command-configuration.md
@@ -1,0 +1,93 @@
+---
+id: agent-command-configuration
+title: Agent Command Configuration
+sidebar_label: Agent Command Configuration
+---
+
+Since version `1.10.0`, the inspectIT Ocelot agent provides the _Agent Commands_ feature, which allows to interact with a specific agent.
+Using this feature is only possible if the agent is used together with the inspectIT Ocelot Configuration-Server.
+
+With this feature it is possible to send specific commands or operations to the agent via the configuration server, which the agent should execute.
+Subsequently, the result of these commands is returned.
+
+It is now possible to interact with the agent.
+Simple commands can be executed, such as a "ping" command whether an agent exists or more complex commands, such as loading the class structure of the application in which the agent is integrated.
+Some new functionality of the configuration server interface is based on this feature, e.g. the _class browser_.
+These functions work only if this feature is enabled.
+
+:::warning
+It is important to note that depending on the complexity of the agent commands, they may have a negative impact on the performance of the target application.
+:::
+
+## How it works
+
+It is important to note that the mentioned agent commands **cannot** be sent directly to the agents.
+For security reasons, **all communication with the agents is initiated by the agents themselves**.
+This means that the agent must always initiate communication and not vice versa.
+
+In order to use the agent commands feature, it must first be enabled, as it is disabled by default.
+See the [Configuration section](configuration/agent-command-configuration.md#configuration) for more information.
+
+Once the feature is enabled, specific agent commands can be triggered via the configuration server.
+The configuration server offers a certain [set of endpoints](https://github.com/inspectIT/inspectit-ocelot/blob/f01ad602a3b188d3be0d17eca22bc4370913b6a1/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/rest/command/AgentCommandController.java) for this purpose. 
+
+Once a command has been created, it is ready for the agent to pick up in the configuration server.
+The agent then asks the configuration server at certain intervals whether new commands exist and obtains the commands assigned to it.
+After that, the respective commands are executed by the agent and the result is sent back to the configuration server.
+
+Due to the fact that the agent fetches the created agent commands in a certain interval, in the worst case it can take exactly the time of the interval until the agent receives a new command.
+However, once the agent receives a command, it switches to its "live"-mode for a specific period of time where it receives commands in near real time.
+If no more commands appear then, the agent will then switch back to normal mode, where it will again obtain the commands at the interval mentioned earlier.
+
+## Configuration
+
+The agent command feature is disabled by default and must be enabled on the agent side.
+This can be achieved with the help of the following configuration:
+
+```YAML
+inspectit:
+  agent-commands:
+    enabled: true
+```
+
+Now the agent has to be configured where it can reach the configuration server and retrieve its commands.
+For this, the following endpoint of the configuration server has to be used: `/api/v1/agent/command`.
+This is achieved by configuring the URL as follows:
+
+```YAML
+inspectit:
+  agent-commands:
+    url: http://<CONFIGURATION_SERVER_AND_PORT>/api/v1/agent/command
+```
+
+As soon as this is activated, the agent obtains the commands stored in the configuration server and executes them.
+The complete configuration for activating the agent commands thus looks as follows.
+
+```YAML
+inspectit:
+  agent-commands:
+    enabled: true
+    url: http://<CONFIGURATION_SERVER_AND_PORT>/api/v1/agent/command
+```
+
+### Dynamic Agent Command URL
+
+In larger environments, where many agents exist and these reach the configuration server under different addresses, it can be cumbersome and difficult to successfully configure the agent command URL.
+Especially if the configuration server HTTP address is already successfully set up, e.g. via JVM properties, you do not want to have to configure the agent command URL additionally.
+
+For this purpose, there is the possibility that the agent derives the agent command URL based on the configured URL for retrieving the agent configuration via HTTP.
+This possibility can be activated by using the following configuration:
+
+```YAML
+inspectit:
+  agent-commands:
+    derive-from-http-config-url: true
+```
+
+:::tip
+This setting takes the URL defined under `inspectit.config.http.url` as a basis.
+:::
+
+This setting has a higher priority than manually specifying the URL.
+If an agent command URL is configured and the `derive-from-http-config-url` option is enabled, the URL is ignored if it is possible to derive the agent command URL based on the HTTP configuration URL.
+

--- a/inspectit-ocelot-documentation/website/sidebars.json
+++ b/inspectit-ocelot-documentation/website/sidebars.json
@@ -11,7 +11,8 @@
       "configuration/external-configuration-sources",
       "configuration/logging-configuration",
       "configuration/open-census-configuration",
-      "configuration/plugin-configuration"
+      "configuration/plugin-configuration",
+      "configuration/agent-command-configuration"
     ],
     "Metrics": [
       "metrics/metrics",


### PR DESCRIPTION
closes #1108

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/1113)
<!-- Reviewable:end -->
