### PR TITLE
Closes #1205 - Reading configuration from mapped Kubernetes Config Maps

### DIFF
--- a/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/FileInfoVisitorTest.java
+++ b/components/inspectit-ocelot-configurationserver/src/test/java/rocks/inspectit/ocelot/file/FileInfoVisitorTest.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -39,6 +40,48 @@ public class FileInfoVisitorTest {
         Files.write(tempFile, test.getBytes(StandardCharsets.UTF_8));
         testFiles.add(tempFile);
         return tempFile;
+    }
+
+    /**
+     * root@inspectit-ocelot-configuration-server-6d58469594-5kk5z:/configuration-server/files# ls -lah
+     * ...
+     * drwxr-xr-x 2 root root 4.0K Sep  1 12:15 ..2021_09_01_12_15_55.274058932
+     * lrwxrwxrwx 1 root root   31 Sep  1 12:15 ..data -> ..2021_09_01_12_15_55.274058932
+     * lrwxrwxrwx 1 root root   16 Sep  1 12:15 some_instrumentation.yml -> ..data/some_instrumentation.yml
+     *
+     * In words:
+     * The folder ..2021_09_01_12_15_55.274058932 contains the some_instrumentation.yml
+     * On the root path, the mysql.yml is a sym link to ..data/some_instrumentation.yml, whereby ..data itself is
+     * a symlink to the folder ..2021_09_01_12_15_55.274058932
+     *
+     */
+    private Path createK8sConfigMapScenario(String test) throws IOException {
+        Path configDir = Files.createTempDirectory("configDir");
+        Path tempFile = Files.createTempFile(configDir, "ocelot", ".yml");
+
+        Files.write(tempFile, test.getBytes(StandardCharsets.UTF_8));
+
+        Path symLinkFromDataToConfigFolder = Paths.get(configDir.getParent().toString(), "..data");
+        Files.createSymbolicLink(symLinkFromDataToConfigFolder, configDir.getFileName());
+
+        Path symLinkConfigFilenameToConfigFile = Paths.get(configDir.getParent().toString(), "some_instrumentation.yml");
+        Files.createSymbolicLink(symLinkConfigFilenameToConfigFile, Paths.get("..data", tempFile.getFileName().toString()));
+
+        // house keeping
+        testFiles.add(symLinkConfigFilenameToConfigFile);
+        testFiles.add(symLinkFromDataToConfigFolder);
+        testFiles.add(tempFile);
+        testFiles.add(configDir);
+
+        return symLinkConfigFilenameToConfigFile;
+    }
+
+    private Path createTestFileInHiddenFolder() throws IOException {
+        Path hiddenFolder = Files.createTempDirectory("..configDir");
+
+        testFiles.add(hiddenFolder);
+
+        return hiddenFolder;
     }
 
     @Nested
@@ -103,6 +146,32 @@ public class FileInfoVisitorTest {
                     .extracting(FileInfo::getName, FileInfo::getType)
                     .contains(tuple(testFile.getFileName().toString(), FileInfo.Type.FILE));
         }
+
+        @Test
+        public void skipSubtreeIfHiddenFolder() throws IOException {
+            Path hiddenFolder = createTestFileInHiddenFolder();
+            FileInfoVisitor visitor = new FileInfoVisitor();
+
+            FileVisitResult result = visitor.preVisitDirectory(hiddenFolder, null);
+
+            assertThat(result.equals(FileVisitResult.SKIP_SUBTREE));
+        }
+
+        @Test
+        public void visitSymbolicLink() throws IOException {
+            Path symbolicLink = createK8sConfigMapScenario("# {}");
+            FileInfoVisitor visitor = new FileInfoVisitor();
+
+            visitor.preVisitDirectory(symbolicLink.getParent(), null);
+            visitor.visitFile(symbolicLink, null);
+
+            List<FileInfo> result = visitor.getFileInfos();
+
+            assertThat(result).hasSize(1)
+                    .extracting(FileInfo::getName, FileInfo::getType)
+                    .contains(tuple(symbolicLink.getFileName().toString(), FileInfo.Type.FILE));
+        }
+
     }
 
 }


### PR DESCRIPTION
Kubernetes uses symlinks within the filesystem to allow updates of Config Maps during runtime.
This fix skips hidden folders with configuration files and symbolic links are followed and read from
in case that a file is referenced by the symbolic link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/1206)
<!-- Reviewable:end -->
