### PR TITLE
Fix editUrl of the Ocelot end-user documentation

### DIFF
--- a/inspectit-ocelot-documentation/website/siteConfig.js
+++ b/inspectit-ocelot-documentation/website/siteConfig.js
@@ -97,7 +97,7 @@ const siteConfig = {
 
   docsSideNavCollapsible: true,
 
-  editUrl: "https://github.com/inspectit/inspectit-ocelot-documentation/edit/master/docs/",
+  editUrl: "https://github.com/inspectIT/inspectit-ocelot/edit/master/inspectit-ocelot-documentation/docs/",
 
   algolia: {
     apiKey: 'ce332dcee733a92cefacc3195edd83dd',


### PR DESCRIPTION
Closes #1389

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/1390)
<!-- Reviewable:end -->
