### PR TITLE
Closes #1407 - Insert events into preloaded logs

### DIFF
--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/selfmonitoring/LogPreloader.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/selfmonitoring/LogPreloader.java
@@ -63,7 +63,8 @@ public class LogPreloader extends DynamicallyActivatableService implements Inter
         if (invalidator != null) {
             String invalidationString = invalidator.getClass().getSimpleName();
             if (invalidationString.endsWith("Event")) {
-                String invalidationLowercase = invalidationString.substring(0, invalidationString.length() - 5)
+                // pretty-format event, e.g., transform 'SomethingHappenedEvent' into 'Something happened'
+                String invalidationLowercase = invalidationString.substring(0, invalidationString.length() - "Event".length())
                         .replaceAll("([a-z])([A-Z]+)", "$1 $2")
                         .toLowerCase();
                 invalidationString = invalidationLowercase.substring(0, 1)

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/selfmonitoring/LogPreloader.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/selfmonitoring/LogPreloader.java
@@ -48,7 +48,7 @@ public class LogPreloader extends DynamicallyActivatableService implements Inter
      */
     @Override
     public void onLoggingEvent(ILoggingEvent event, Class<?> invalidator) {
-        if (buffer != null && event.getLevel().isGreaterOrEqual(minimumPreloadingLevel)) {
+        if (event.getLevel().isGreaterOrEqual(minimumPreloadingLevel)) {
             recordLoggingEvent(event);
         }
     }
@@ -76,12 +76,14 @@ public class LogPreloader extends DynamicallyActivatableService implements Inter
     }
 
     private void recordLoggingEvent(ILoggingEvent event) {
-        int index = currentIndex.getAndIncrement() % buffer.length;
-        try {
-            buffer[index] = event;
-        } catch (ArrayIndexOutOfBoundsException e) {
-            // this may happen while the buffer gets recreated with a smaller size
-            // in this case, we just drop the event until everything is properly set again
+        if (buffer != null) {
+            int index = currentIndex.getAndIncrement() % buffer.length;
+            try {
+                buffer[index] = event;
+            } catch (ArrayIndexOutOfBoundsException e) {
+                // this may happen while the buffer gets recreated with a smaller size
+                // in this case, we just drop the event until everything is properly set again
+            }
         }
     }
 

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/selfmonitoring/LogPreloader.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/selfmonitoring/LogPreloader.java
@@ -5,6 +5,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import rocks.inspectit.ocelot.config.model.InspectitConfig;
 import rocks.inspectit.ocelot.config.model.selfmonitoring.LogPreloadingSettings;
@@ -26,6 +27,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class LogPreloader extends DynamicallyActivatableService implements InternalProcessingAppender.LogEventConsumer {
 
     private static final String LOG_INVALIDATION_EVENT = "{}! Some previous log messages may now be outdated.";
+
+    private final Logger invalidationLogger = (Logger) LoggerFactory.getLogger("### LOG-INVALIDATING EVENT ###");
 
     private ILoggingEvent[] buffer;
 
@@ -67,7 +70,7 @@ public class LogPreloader extends DynamicallyActivatableService implements Inter
                         .toUpperCase() + invalidationLowercase.substring(1);
             }
 
-            ILoggingEvent logEvent = new LoggingEvent(getClass().getName(), (Logger) log, Level.INFO, LOG_INVALIDATION_EVENT, null, new String[]{invalidationString});
+            ILoggingEvent logEvent = new LoggingEvent(getClass().getName(), invalidationLogger, Level.INFO, LOG_INVALIDATION_EVENT, null, new String[]{invalidationString});
             recordLoggingEvent(logEvent);
         }
     }


### PR DESCRIPTION
Artificially added log events will look like follows.

`2022-04-29 10:47:42,709 INFO  33860  --- [inspectIT] [pectit-thread-1] ### LOG-INVALIDATING EVENT ###           : Property sources reload! Some previous log messages may now be outdated.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/1411)
<!-- Reviewable:end -->
