### PR TITLE
Export metric about duration of JDBC queries

### DIFF
--- a/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/actions/db/jdbc.yml
+++ b/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/actions/db/jdbc.yml
@@ -34,3 +34,15 @@ inspectit:
           } catch (Exception e) { // in case the connection is closed
             return null;
           }
+    
+      'a_jdbc_extract_sql_command':
+        docs:
+          description: |-
+            Extracts the command (e.g., SELECT, UPDATE, CALL, ...) from a SQL query.
+            The used heuristic takes everything before the first blank.
+          inputs:
+            'sql_query': 'A string containing the SQL query from which the command will be extracted.'
+          return-value: 'The SQL command as string.'
+        input:
+          'sql_query': 'String'
+        value: 'sql_query.trim().split("\\s+")[0].toUpperCase()'

--- a/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/actions/db/jdbc.yml
+++ b/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/actions/db/jdbc.yml
@@ -46,9 +46,10 @@ inspectit:
         input:
           'statement': 'String'
         value-body: |
-          int index = statement.indexOf(' ');
+          String statementTrimmed = statement.trim();
+          int index = statementTrimmed.indexOf(' ');
           if (index > -1) {
-              return statement.substring(0, index).trim();
+              return statementTrimmed.substring(0, index).trim();
           } else {
-              return statement;
+              return statementTrimmed;
           }

--- a/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/actions/db/jdbc.yml
+++ b/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/actions/db/jdbc.yml
@@ -44,5 +44,11 @@ inspectit:
             'sql_query': 'A string containing the SQL query from which the command will be extracted.'
           return-value: 'The SQL command as string.'
         input:
-          'sql_query': 'String'
-        value: 'sql_query.trim().split("\\s+")[0].toUpperCase()'
+          'statement': 'String'
+        value-body: |
+          int index = statement.indexOf(' ');
+          if (index > -1) {
+              return statement.substring(0, index).trim();
+          } else {
+              return statement;
+          }

--- a/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/rules/db/jdbc/metrics.yml
+++ b/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/rules/db/jdbc/metrics.yml
@@ -1,0 +1,89 @@
+inspectit:
+  metrics:
+    definitions:
+
+      '[jdbc/query/duration]':
+        unit: ms
+        description: 'the duration of JDBC queries'
+        views:
+          '[jdbc/query/duration/sum]':
+            aggregation: SUM
+            tags:
+              'jdbc_url': true
+              'sql_command' : true # e.g., SELECT, UPDATE, CALL, ...
+              'jdbc_operation': true # e.g., execute, executeUpdate, executeBatch, ...
+          '[jdbc/query/duration/count]':
+            aggregation: COUNT
+            tags:
+              'jdbc_url': true
+              'sql_command': true
+              'jdbc_operation': true
+  
+  instrumentation:
+    rules:
+      
+      'r_jdbc_query_metric_statement_execute':
+        docs:
+          description: 'Collects metrics for execute/executeUpdate calls with non-prepared SQL (the SQL is given as method argument).'
+        include:
+          'r_jdbc_query_metric_defaults': true
+        scopes:
+          's_jdbc_statement_execute': true
+        exit:
+          'db_sql_query':
+            action: 'a_assign_value'
+            data-input:
+              'value': _arg0
+      
+      'r_jdbc_query_metric_statement_executeBatch':
+        docs:
+          description: 'Collects metrics for executeBatch calls with non-prepared SQL.'
+        include:
+          'r_jdbc_query_metric_defaults': true
+        scopes:
+          's_jdbc_statement_executeBatch': true
+
+      'r_jdbc_query_metric_preparedstatement':
+        docs:
+          description: 'Collects metrics for execute/executeUpdate/executeBatch calls with prepared SQL.'
+        include:
+          'r_jdbc_query_metric_defaults': true
+        scopes:
+          's_jdbc_preparedstatement_execute': true
+          's_jdbc_preparedstatement_executeBatch': true
+        exit:
+          'db_sql_query':
+            action: 'a_assign_value'
+            data-input:
+              'value': 'prepared_sql' # prepared_sql is populated and up-propagated by driver instrumentations
+          
+      # ---------------------------------------------------------------
+      # Shared JDBC metric rules below
+      # ---------------------------------------------------------------
+      
+      'r_jdbc_query_metric_defaults':
+        docs:
+          description: |-
+            Collects the metric [jdbc/query/duration]. To be included in JDBC query metric collection rules.
+            Rules that include it should provide the context variable 'db_sql_query'.
+        include:
+          'r_capture_method_duration_conditional': true
+          'r_jdbc_detect_entry': true
+          'r_jdbc_extract_url': true
+        entry:
+          'capture_time_condition':
+            action: 'a_assign_true'
+            only-if-true: 'jdbc_is_entry'
+        exit:
+          'sql_command':
+            action: 'a_jdbc_extract_sql_command'
+            only-if-not-null: 'db_sql_query'
+            data-input:
+              'sql_query': 'db_sql_query' # is set by the specific rules above
+        metrics:
+          '[jdbc/query/duration]':
+            value: 'method_duration'
+            data-tags:
+              'jdbc_url': 'jdbc_url'
+              'sql_command': 'sql_command'
+              'jdbc_operation': _methodName

--- a/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/rules/db/jdbc/metrics.yml
+++ b/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/rules/db/jdbc/metrics.yml
@@ -9,14 +9,14 @@ inspectit:
           '[jdbc/query/duration/sum]':
             aggregation: SUM
             tags:
-              'jdbc_url': true
-              'sql_command' : true # e.g., SELECT, UPDATE, CALL, ...
+              'db.connection_string': true
+              'db.operation' : true # e.g., SELECT, UPDATE, CALL, ...
               'jdbc_operation': true # e.g., execute, executeUpdate, executeBatch, ...
           '[jdbc/query/duration/count]':
             aggregation: COUNT
             tags:
-              'jdbc_url': true
-              'sql_command': true
+              'db.connection_string': true
+              'db.operation': true
               'jdbc_operation': true
   
   instrumentation:
@@ -30,7 +30,7 @@ inspectit:
         scopes:
           's_jdbc_statement_execute': true
         exit:
-          'db_sql_query':
+          'c_db_sql_query':
             action: 'a_assign_value'
             data-input:
               'value': _arg0
@@ -52,7 +52,7 @@ inspectit:
           's_jdbc_preparedstatement_execute': true
           's_jdbc_preparedstatement_executeBatch': true
         exit:
-          'db_sql_query':
+          'c_db_sql_query':
             action: 'a_assign_value'
             data-input:
               'value': 'prepared_sql' # prepared_sql is populated and up-propagated by driver instrumentations
@@ -65,7 +65,7 @@ inspectit:
         docs:
           description: |-
             Collects the metric [jdbc/query/duration]. To be included in JDBC query metric collection rules.
-            Rules that include it should provide the context variable 'db_sql_query'.
+            Rules that include it should provide the context variable 'c_db_sql_query'.
         include:
           'r_capture_method_duration_conditional': true
           'r_jdbc_detect_entry': true
@@ -75,15 +75,15 @@ inspectit:
             action: 'a_assign_true'
             only-if-true: 'jdbc_is_entry'
         exit:
-          'sql_command':
+          'c_sql_command':
             action: 'a_jdbc_extract_sql_command'
-            only-if-not-null: 'db_sql_query'
+            only-if-not-null: 'c_db_sql_query'
             data-input:
-              'sql_query': 'db_sql_query' # is set by the specific rules above
+              'statement': 'c_db_sql_query' # is set by the specific rules above
         metrics:
           '[jdbc/query/duration]':
             value: 'method_duration'
             data-tags:
-              'jdbc_url': 'jdbc_url'
-              'sql_command': 'sql_command'
+              'db.connection_string': 'jdbc_url'
+              'db.operation': 'c_sql_command'
               'jdbc_operation': _methodName


### PR DESCRIPTION
The provided changes collect the metric jdbc/query/duration with views sum and count. The labels are the requested database (`jdbc_url`), the command like SELECT, UPDATE, ... (`sql_command`) and the called JDBC method (`jdbc_operation`).

The metric is a missing counterpart to the JDBC span collection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/1420)
<!-- Reviewable:end -->
