### PR TITLE
feat #1124: Create agent command for fetching details about an agent

### DIFF
--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/agentcommunication/handlers/impl/EnvironmentCommandHandler.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/agentcommunication/handlers/impl/EnvironmentCommandHandler.java
@@ -1,0 +1,87 @@
+package rocks.inspectit.ocelot.agentcommunication.handlers.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.async.DeferredResult;
+import rocks.inspectit.ocelot.agentcommunication.handlers.CommandHandler;
+import rocks.inspectit.ocelot.commons.models.command.Command;
+import rocks.inspectit.ocelot.commons.models.command.CommandResponse;
+import rocks.inspectit.ocelot.commons.models.command.impl.EnvironmentCommand;
+import rocks.inspectit.ocelot.config.model.InspectitServerSettings;
+
+import java.time.Duration;
+
+/**
+ * Handler for the Agent Environment command.
+ */
+@Slf4j
+@Component
+public class EnvironmentCommandHandler implements CommandHandler {
+
+    @Autowired
+    private InspectitServerSettings configuration;
+
+    /**
+     * Checks if the given {@link Command} is an instance of {@link EnvironmentCommand}.
+     *
+     * @param command The command which should be checked.
+     *
+     * @return True if the given command is an instance of {@link EnvironmentCommand}.
+     */
+    @Override
+    public boolean canHandle(Command command) {
+        return command instanceof EnvironmentCommand;
+    }
+
+    /**
+     * Checks if the given {@link CommandResponse} is an instance of {@link EnvironmentCommand.Response}.
+     *
+     * @param response The response which should be checked.
+     *
+     * @return True if the given response is an instance of {@link EnvironmentCommand.Response}.
+     */
+    @Override
+    public boolean canHandle(CommandResponse response) {
+        return response instanceof EnvironmentCommand.Response;
+    }
+
+    /**
+     * Prepares an instance of {@link DeferredResult} by setting the Timeout as well as the onTimeout function.
+     * This onTimeout function sets the {@link ResponseEntity} to the status REQUEST_TIMEOUT.
+     *
+     * @param agentId The id of the agent the command is meant for.
+     * @param command The command to be Executed.
+     *
+     * @return An instance of  {@link DeferredResult} with a set timeout value and a set timeout function.
+     */
+    @Override
+    public DeferredResult<ResponseEntity<?>> prepareResponse(String agentId, Command command) {
+        if (!canHandle(command)) {
+            throw new IllegalArgumentException("EnvironmentCommandHandler can only handle commands of type EnvironmentCommand.");
+        }
+
+        Duration responseTimeout = configuration.getAgentCommand().getResponseTimeout();
+        DeferredResult<ResponseEntity<?>> deferredResult = new DeferredResult<>(responseTimeout.toMillis());
+        deferredResult.onTimeout(() -> ResponseEntity.status(HttpStatus.REQUEST_TIMEOUT).build());
+
+        return deferredResult;
+    }
+
+    /**
+     * Takes an instance of {@link CommandResponse} as well as an instance of {@link DeferredResult}. Sets the
+     * {@link ResponseEntity} of the {@link DeferredResult} to the status OK. In this handler the given response is
+     * ignored since the response itself indicates that the agent is alive.
+     *
+     * @param response The {@link CommandResponse} to be handled.
+     * @param result   The {@link DeferredResult} the response should be written in.
+     */
+    @Override
+    public void handleResponse(CommandResponse response, DeferredResult<ResponseEntity<?>> result) {
+        EnvironmentCommand.Response environmentResponse = (EnvironmentCommand.Response) response;
+        result.setResult(ResponseEntity.ok().body(environmentResponse.getEnvironment()));
+    }
+
+}

--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/rest/command/AgentCommandController.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/rest/command/AgentCommandController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.async.DeferredResult;
 import rocks.inspectit.ocelot.agentcommunication.AgentCommandDispatcher;
+import rocks.inspectit.ocelot.commons.models.command.impl.EnvironmentCommand;
 import rocks.inspectit.ocelot.commons.models.command.impl.ListClassesCommand;
 import rocks.inspectit.ocelot.commons.models.command.impl.LogsCommand;
 import rocks.inspectit.ocelot.commons.models.command.impl.PingCommand;
@@ -48,5 +49,11 @@ public class AgentCommandController extends AbstractBaseController {
     public DeferredResult<ResponseEntity<?>> listClasses(@RequestParam(value = "agent-id") String agentId, @RequestParam(value = "query") String query) throws ExecutionException {
         ListClassesCommand listClassesCommand = new ListClassesCommand(query);
         return commandDispatcher.dispatchCommand(agentId, listClassesCommand);
+    }
+
+    @GetMapping(value = "command/environment")
+    public DeferredResult<ResponseEntity<?>> environment(@RequestParam(value = "agent-id") String agentId) throws ExecutionException {
+        EnvironmentCommand environmentCommand = new EnvironmentCommand();
+        return commandDispatcher.dispatchCommand(agentId, environmentCommand);
     }
 }

--- a/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/commons/models/command/Command.java
+++ b/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/commons/models/command/Command.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import rocks.inspectit.ocelot.commons.models.command.impl.EnvironmentCommand;
 import rocks.inspectit.ocelot.commons.models.command.impl.ListClassesCommand;
 import rocks.inspectit.ocelot.commons.models.command.impl.PingCommand;
 import rocks.inspectit.ocelot.commons.models.command.impl.LogsCommand;
@@ -20,7 +21,8 @@ import java.util.UUID;
 @JsonSubTypes(value = {
         @JsonSubTypes.Type(name = PingCommand.TYPE_IDENTIFIER, value = PingCommand.class),
         @JsonSubTypes.Type(name = ListClassesCommand.TYPE_IDENTIFIER, value = ListClassesCommand.class),
-        @JsonSubTypes.Type(name = LogsCommand.TYPE_IDENTIFIER, value = LogsCommand.class)
+        @JsonSubTypes.Type(name = LogsCommand.TYPE_IDENTIFIER, value = LogsCommand.class),
+        @JsonSubTypes.Type(name = EnvironmentCommand.TYPE_IDENTIFIER, value = EnvironmentCommand.class)
 })
 public abstract class Command {
 

--- a/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/commons/models/command/CommandResponse.java
+++ b/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/commons/models/command/CommandResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import rocks.inspectit.ocelot.commons.models.command.impl.EnvironmentCommand;
 import rocks.inspectit.ocelot.commons.models.command.impl.ListClassesCommand;
 import rocks.inspectit.ocelot.commons.models.command.impl.LogsCommand;
 import rocks.inspectit.ocelot.commons.models.command.impl.PingCommand;
@@ -22,6 +23,7 @@ import java.util.UUID;
         @JsonSubTypes.Type(name = PingCommand.TYPE_IDENTIFIER, value = PingCommand.Response.class),
         @JsonSubTypes.Type(name = ListClassesCommand.TYPE_IDENTIFIER, value = ListClassesCommand.Response.class),
         @JsonSubTypes.Type(name = LogsCommand.TYPE_IDENTIFIER, value = LogsCommand.Response.class),
+        @JsonSubTypes.Type(name = EnvironmentCommand.TYPE_IDENTIFIER, value = EnvironmentCommand.Response.class),
 })
 public abstract class CommandResponse {
 

--- a/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/commons/models/command/impl/EnvironmentCommand.java
+++ b/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/commons/models/command/impl/EnvironmentCommand.java
@@ -1,0 +1,50 @@
+package rocks.inspectit.ocelot.commons.models.command.impl;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import rocks.inspectit.ocelot.commons.models.command.Command;
+import rocks.inspectit.ocelot.commons.models.command.CommandResponse;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Represents an Environment-Command. Environment commands are used to receive the details of a certain agent.
+ */
+@Data
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class EnvironmentCommand extends Command {
+
+    /**
+     * Type identifier for JSON serialization.
+     */
+    public static final String TYPE_IDENTIFIER = "environment";
+
+    /**
+     * Represents a response to the {@link EnvironmentCommand}.
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    public static class Response extends CommandResponse {
+        private EnvironmentDetail environment;
+    }
+
+    /**
+     * Represents the structure of the returned environment details
+     */
+    @Data
+    public static class EnvironmentDetail {
+        @JsonPropertyOrder(alphabetic=true)
+        private Map<String, String> environmentVariables;
+        @JsonPropertyOrder(alphabetic=true)
+        private Properties systemProperties;
+        private List<String> jvmArguments;
+    }
+}

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/command/HttpCommandFetcher.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/command/HttpCommandFetcher.java
@@ -34,7 +34,7 @@ public class HttpCommandFetcher {
     /**
      * Object mapper for serializing command responses.
      */
-    private final ObjectMapper objectMapper = new ObjectMapper().enableDefaultTyping();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
      * The prefix which is used for the meta information HTTP headers.

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/command/handler/impl/EnvironmentCommandExecutor.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/command/handler/impl/EnvironmentCommandExecutor.java
@@ -1,0 +1,56 @@
+package rocks.inspectit.ocelot.core.command.handler.impl;
+
+import org.springframework.stereotype.Component;
+import rocks.inspectit.ocelot.commons.models.command.Command;
+import rocks.inspectit.ocelot.commons.models.command.CommandResponse;
+import rocks.inspectit.ocelot.commons.models.command.impl.EnvironmentCommand;
+import rocks.inspectit.ocelot.core.command.handler.CommandExecutor;
+
+import java.lang.management.ManagementFactory;
+
+/**
+ * Executor for executing {@link EnvironmentCommand}s.
+ */
+@Component
+public class EnvironmentCommandExecutor implements CommandExecutor {
+
+    /**
+     * Checks if the given {@link Command} is an instance of {@link EnvironmentCommand}.
+     *
+     * @param command The {@link Command} to be checked.
+     *
+     * @return True if the given {@link Command} is an instance of {@link EnvironmentCommand}.
+     */
+    @Override
+    public boolean canExecute(Command command) {
+        return command instanceof EnvironmentCommand;
+    }
+
+    /**
+     * Executes the given {@link Command}. Throws an {@link IllegalArgumentException} if the given command is either null
+     * or not handled by this implementation.
+     *
+     * @param command The command to be executed.
+     *
+     * @return An instance of {@link EnvironmentCommand} with alive set to true and the id of the given command.
+     */
+    @Override
+    public CommandResponse execute(Command command) {
+        if (!canExecute(command)) {
+            String exceptionMessage = "Invalid command type. Executor does not support commands of type " + command.getClass();
+            throw new IllegalArgumentException(exceptionMessage);
+        }
+
+        EnvironmentCommand.Response response = new EnvironmentCommand.Response();
+        response.setCommandId(command.getCommandId());
+
+        EnvironmentCommand.EnvironmentDetail body = new EnvironmentCommand.EnvironmentDetail();
+        body.setEnvironmentVariables(System.getenv());
+        body.setSystemProperties(System.getProperties());
+        body.setJvmArguments(ManagementFactory.getRuntimeMXBean().getInputArguments());
+
+        response.setEnvironment(body);
+
+        return response;
+    }
+}

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/metrics/system/ProcessorMetricsRecorder.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/metrics/system/ProcessorMetricsRecorder.java
@@ -67,7 +67,7 @@ public class ProcessorMetricsRecorder extends AbstractPollingMetricsRecorder {
         if (!systemCpuUsage.isPresent()) {
             log.info(METRIC_UNAVAILABLE, SYSTEM_USAGE_METRIC_FULL_NAME, METH_SYS_CPU_LOAD);
         }
-        if (!systemCpuUsage.isPresent()) {
+        if (!processCpuUsage.isPresent()) {
             log.info(METRIC_UNAVAILABLE, PROCESS_USAGE_METRIC_FULL_NAME, METH_PROC_CPU_LOAD);
         }
         if (!averageLoadAvailable) {

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/command/handler/impl/EnvironmentCommandExecutorTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/command/handler/impl/EnvironmentCommandExecutorTest.java
@@ -1,0 +1,108 @@
+package rocks.inspectit.ocelot.core.command.handler.impl;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import rocks.inspectit.ocelot.commons.models.command.impl.EnvironmentCommand;
+import rocks.inspectit.ocelot.config.model.command.AgentCommandSettings;
+import rocks.inspectit.ocelot.core.SpringTestBase;
+import rocks.inspectit.ocelot.core.config.InspectitEnvironment;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@ExtendWith(MockitoExtension.class)
+public class EnvironmentCommandExecutorTest {
+
+    static final String tmpDir = "tmpconf_int_test";
+
+    static final String configurationA = "inspectit:\n  agent-commands:\n    enabled: true\n    url: http://localhost:8090/api/v1/agent/command";
+
+    @BeforeAll
+    static void createConfigDir() {
+        new File(tmpDir).mkdir();
+    }
+
+    @BeforeEach
+    void cleanConfigDir() throws Exception {
+        FileUtils.cleanDirectory(new File(tmpDir));
+    }
+
+    @AfterAll
+    static void deleteConfigDir() throws Exception {
+        FileUtils.deleteDirectory(new File(tmpDir));
+    }
+
+    @Nested
+    @DirtiesContext
+    @TestPropertySource(properties = {"inspectit.config.file-based.path=" + tmpDir, "inspectit.config.file-based.frequency=50ms"})
+    public class Configuration extends SpringTestBase {
+
+        @Autowired
+        InspectitEnvironment env;
+
+        @Test
+        public void test() throws IOException {
+            testConfiguration(configurationA, true, new URL("http://localhost:8090/api/v1/agent/command"));
+        }
+
+        private void testConfiguration(String configuration, boolean enabled, URL commandUrl) throws IOException {
+            FileUtils.write(new File(tmpDir + "/env-command.yml"), configuration, Charset.defaultCharset());
+
+            await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {
+                AgentCommandSettings settings = env.getCurrentConfig().getAgentCommands();
+                assertThat(settings).isNotNull();
+                assertThat(settings.isEnabled()).isEqualTo(enabled);
+                assertThat(settings.getUrl()).isEqualTo(commandUrl);
+            });
+        }
+
+    }
+
+    @Nested
+    @DirtiesContext
+    public class Execute {
+
+        @InjectMocks
+        EnvironmentCommandExecutor executor;
+
+        @Test
+        public void testLogFormat() {
+
+            EnvironmentCommand command = new EnvironmentCommand();
+            command.setCommandId(UUID.randomUUID());
+            EnvironmentCommand.Response response = (EnvironmentCommand.Response) executor.execute(command);
+
+            // available environment variables should be returned
+            assertThat(response.getEnvironment().getEnvironmentVariables().size()).isGreaterThan(0);
+            assertThat(response.getEnvironment().getEnvironmentVariables()).containsKey("PATH");
+
+            // system properties should be returned
+            assertThat(response.getEnvironment().getSystemProperties().size()).isGreaterThan(0);
+            assertThat(response.getEnvironment().getSystemProperties()).containsKey("os.name");
+            assertThat(response.getEnvironment().getSystemProperties()).containsKey("java.version");
+
+            // any jvm arguments passed in the starting command should be returned
+            assertThat(response.getEnvironment().getJvmArguments().size()).isGreaterThan(0);
+        }
+
+    }
+
+}


### PR DESCRIPTION
Closes #1124

Added new command endpoint /command/environment?agent-id=xxx to retrieve info about environment variables, jvm properties and the arguments passed to the jvm on startup.
