### PR TITLE
bug #1476:  Configuration UI shows invalid agent summary when "combine services" is used

### DIFF
--- a/components/inspectit-ocelot-configurationserver-ui/src/components/views/status/StatusView.js
+++ b/components/inspectit-ocelot-configurationserver-ui/src/components/views/status/StatusView.js
@@ -76,7 +76,6 @@ class StatusView extends React.Component {
           const agentFilter = this.getAgentFilter(agent);
           return this.checkRegex(agentFilter, regex);
         });
-
         this.setState(
           {
             error: false,
@@ -134,10 +133,9 @@ class StatusView extends React.Component {
         }
         return result;
       }, {});
-
       this.setState({
         error: false,
-        agentsToShow: mergedMap,
+        agentsToShow: Object.values(mergedMap),
       });
     }
   };


### PR DESCRIPTION
Fixed the issue. Caused by the footer expecting an array of agents, but getting a map-like object when combining services.