### PR TITLE
[WIP] feat: Set scope properties in Method Configuration UI

### DIFF
--- a/components/inspectit-ocelot-configurationserver-ui/src/components/editor/method-configuration-editor/MethodConfigurationEditor.js
+++ b/components/inspectit-ocelot-configurationserver-ui/src/components/editor/method-configuration-editor/MethodConfigurationEditor.js
@@ -75,6 +75,8 @@ const MethodConfigurationEditor = ({ yamlConfiguration }) => {
     });
     setScopes(currentScopes);
 
+    console.info('Current Scopes: ', currentScopes);
+
     // expand all rows by default
     const initialExpandedRows = _.reduce(
       currentScopes,
@@ -93,7 +95,8 @@ const MethodConfigurationEditor = ({ yamlConfiguration }) => {
    * @param {*} typeMatcher the class instrumentation settings
    * @param {*} methodMatcher the method instrumentation settings
    */
-  const prepareScope = (typeMatcher, methodMatcher) => {
+  const prepareScope = (scopeProperties, typeMatcher, methodMatcher) => {
+    console.error('Method Config - Scope Props: ', scopeProperties);
     // Prepare class matcher
     const type = typeMatcher.type;
     const classMatcherType = typeMatcher.matcherType;
@@ -136,7 +139,9 @@ const MethodConfigurationEditor = ({ yamlConfiguration }) => {
    * @param {*} typeMatcher the class instrumentation settings
    * @param {*} methodMatcher the method instrumentation settings
    */
-  const addScope = (typeMatcher, methodMatcher) => {
+  const addScope = (scopeProperties, typeMatcher, methodMatcher) => {
+    console.warn('Method Config - Set Scope name');
+
     const cloneConfiguration = _.cloneDeep(configuration);
     let scopeName;
     // Check whether an existing scope was modified or a new scope created
@@ -152,7 +157,7 @@ const MethodConfigurationEditor = ({ yamlConfiguration }) => {
       _.set(cloneConfiguration, ['inspectit', 'instrumentation', 'rules', 'r_method_configuration_duration', 'scopes', scopeName], true);
     }
 
-    const preparedScope = prepareScope(typeMatcher, methodMatcher);
+    const preparedScope = prepareScope(scopeProperties, typeMatcher, methodMatcher);
 
     try {
       _.set(cloneConfiguration, ['inspectit', 'instrumentation', 'scopes', scopeName], preparedScope);
@@ -169,9 +174,9 @@ const MethodConfigurationEditor = ({ yamlConfiguration }) => {
    * @param {*} newConfiguration the new configuration
    */
   const updateConfiguration = (newConfiguration) => {
+    console.warn('(MCE): new Config: ', newConfiguration);
     try {
       const updatedYamlConfiguration = '# {"type": "Method-Configuration"}\n' + yaml.dump(newConfiguration);
-
       dispatch(selectedFileContentsChanged(updatedYamlConfiguration));
     } catch (error) {
       console.error('Configuration could not been updated.', error);
@@ -234,7 +239,19 @@ const MethodConfigurationEditor = ({ yamlConfiguration }) => {
    * @param {*} scopeName the name of the target scope
    * @param {*} stateRule  the rule to update
    */
-  const scopeStateBodyTemplate = (scopeName, stateRule) => {
+  const scopeStateBodyTemplate = (currentScope, scopeName, stateRule) => {
+    // ToDo: add scope props to file content
+    console.warn('Change scope temp to unclude props');
+    // console.log('current scope: ', currentScope);
+    // console.log('outdated scope name: ', scopeName);
+
+    // collect existing scopes from the configuration
+    const scopeObjects = _.get(configuration, 'inspectit.instrumentation.rules');
+    console.info('Scope config from condig: ', scopeObjects);
+    // setScopes(scopeObjects);
+
+    // scopeProperties
+
     const ruleScopePath = 'inspectit.instrumentation.rules.' + stateRule + '.scopes.' + scopeName;
     const ruleState = _.get(configuration, ruleScopePath);
 
@@ -347,12 +364,12 @@ const MethodConfigurationEditor = ({ yamlConfiguration }) => {
             >
               <Column body={scopeDescriptionBodyTemplate} header="Target" />
               <Column
-                body={({ name }) => scopeStateBodyTemplate(name, SCOPE_STATES_RULES.TRACING)}
+                body={({ name }) => scopeStateBodyTemplate(currentScope, name, SCOPE_STATES_RULES.TRACING)}
                 header="Trace"
                 style={{ width: '6rem' }}
               />
               <Column
-                body={({ name }) => scopeStateBodyTemplate(name, SCOPE_STATES_RULES.MEASURING)}
+                body={({ name }) => scopeStateBodyTemplate(currentScope, name, SCOPE_STATES_RULES.MEASURING)}
                 header="Measure"
                 style={{ width: '6rem' }}
               />

--- a/components/inspectit-ocelot-configurationserver-ui/src/components/views/configuration/scope-wizard/ScopeProps.js
+++ b/components/inspectit-ocelot-configurationserver-ui/src/components/views/configuration/scope-wizard/ScopeProps.js
@@ -1,0 +1,96 @@
+import { Fieldset } from 'primereact/fieldset';
+import { InputText } from 'primereact/inputtext';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/** data */
+import { TOOLTIP_OPTIONS } from '../../../../data/constants';
+import { DEFAULT_SCOPE_PROPS_STATE } from './ScopeWizardDialog';
+
+const ScopeProps = ({ scopeProperties, onScopePropsChange }) => {
+  const setState = (stateArgument, value) => {
+    const currentScopePropertiesMatcher = {
+      ...scopeProperties,
+      [stateArgument]: value,
+    };
+    onScopePropsChange(currentScopePropertiesMatcher);
+  };
+
+  return (
+    <>
+      <style jsx>{`
+        .row-center {
+          display: flex;
+          align-items: center;
+          margin-top: 0.5rem;
+        }
+
+        .row-center :global(.fill),
+        .fill {
+          flex-grow: 1;
+        }
+
+        .row-center label {
+          margin-right: 2rem;
+        }
+
+        .row-center label:not(:first-child) {
+          margin-left: 0.5rem;
+        }
+
+        .row-center .inner-label {
+          margin-left: 0.5rem;
+          margin-right: 0.5rem;
+        }
+
+        .row-center .input-text {
+          margin-left: 0.5rem;
+        }
+      `}</style>
+
+      <Fieldset legend="Scope properties" style={{ paddingTop: 0, paddingBottom: '1rem' }}>
+        <div className="row-center">
+          <label className="inner-label" htmlFor="which">
+            Name:
+          </label>
+          <div className="p-inputgroup input-text fill">
+            <InputText
+              className="fill"
+              value={scopeProperties?.name === undefined ? DEFAULT_SCOPE_PROPS_STATE.name : scopeProperties.name}
+              onChange={(e) => setState('name', e.target.value)}
+              placeholder="Name of scope"
+              tooltip="The name of the scope for the type matcher."
+              tooltipOptions={TOOLTIP_OPTIONS}
+            />
+          </div>
+          <label className="inner-label" htmlFor="which">
+            Description:
+          </label>
+          <div className="p-inputgroup input-text fill">
+            <InputText
+              className="fill"
+              value={scopeProperties?.description === undefined ? DEFAULT_SCOPE_PROPS_STATE.description : scopeProperties.description}
+              onChange={(e) => setState('description', e.target.value)}
+              placeholder="Description of scope"
+              tooltip="The description of the scope for the type matcher."
+              tooltipOptions={TOOLTIP_OPTIONS}
+            />
+          </div>
+        </div>
+      </Fieldset>
+    </>
+  );
+};
+
+ScopeProps.propTypes = {
+  /** Scope Properties state */
+  scopeProperties: PropTypes.object,
+  /** Callback on scope properties change */
+  onScopePropsChange: PropTypes.func,
+};
+
+ScopeProps.defaultProps = {
+  onScopePropsChange: () => {},
+};
+
+export default ScopeProps;

--- a/components/inspectit-ocelot-configurationserver-ui/src/components/views/configuration/scope-wizard/ScopeWizardDialog.js
+++ b/components/inspectit-ocelot-configurationserver-ui/src/components/views/configuration/scope-wizard/ScopeWizardDialog.js
@@ -3,6 +3,7 @@ import { Dialog } from 'primereact/dialog';
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
+import ScopeProps from './ScopeProps';
 import TypeMatcher from './TypeMatcher';
 import MethodMatcher from './MethodMatcher';
 import ClassBrowserDialog from '../../../common/class-browser/ClassBrowserDialog';
@@ -10,6 +11,7 @@ import ClassBrowserDialog from '../../../common/class-browser/ClassBrowserDialog
 /** data */
 import { DEFAULT_VISIBILITIES } from '../../../editor/method-configuration-editor/constants';
 
+export const DEFAULT_SCOPE_PROPS_STATE = { name: '', description: '' };
 const DEFAULT_TYPE_MATCHER_STATE = { type: 'type', matcherType: 'EQUALS_FULLY', name: '' };
 
 const DEFAULT_METHOD_MATCHER_STATE = {
@@ -26,6 +28,7 @@ const DEFAULT_METHOD_MATCHER_STATE = {
  * The scope wizard dialog itself.
  */
 const ScopeWizardDialog = ({ visible, onHide, onApply, scope }) => {
+  const [scopeProperties, setScopeProperties] = useState({ ...DEFAULT_SCOPE_PROPS_STATE });
   const [typeMatcher, setTypeMatcher] = useState({ ...DEFAULT_TYPE_MATCHER_STATE });
   const [methodMatcher, setMethodMatcher] = useState({ ...DEFAULT_METHOD_MATCHER_STATE });
 
@@ -37,6 +40,7 @@ const ScopeWizardDialog = ({ visible, onHide, onApply, scope }) => {
   useEffect(() => {
     // Set default state
     if (visible) {
+      const preparedScopeProperties = { ...DEFAULT_SCOPE_PROPS_STATE };
       const preparedTypeMatcher = { ...DEFAULT_TYPE_MATCHER_STATE };
       const preparedMethodMatcher = { ...DEFAULT_METHOD_MATCHER_STATE };
       // When edit mode, fill out dialog
@@ -60,12 +64,18 @@ const ScopeWizardDialog = ({ visible, onHide, onApply, scope }) => {
           throw new Error('Scopes using multiple type matchers are currently not supported.');
         }
 
+        console.error('Scope Wizard Scope', scope);
+
+        preparedScopeProperties.name = preparedScopeProperties?.name === undefined ? DEFAULT_SCOPE_PROPS_STATE.name : preparedScopeProperties.name;
+        preparedScopeProperties.description = preparedScopeProperties?.description === undefined ? DEFAULT_SCOPE_PROPS_STATE.description : preparedScopeProperties.description;
         preparedTypeMatcher.type = targetType;
         preparedTypeMatcher.matcherType = _.get(targetMatcher, 'matcher-mode', 'EQUALS_FULLY');
         preparedTypeMatcher.name = _.get(targetMatcher, 'name', '');
 
         // set method matcher
         const { methods } = scope;
+
+        console.error('Scope Wizard Methods', methods);
 
         if (methods && methods.length === 1) {
           const method = methods[0];
@@ -77,6 +87,7 @@ const ScopeWizardDialog = ({ visible, onHide, onApply, scope }) => {
           preparedMethodMatcher.name = _.get(method, 'name', '');
         }
       }
+      setScopeProperties(preparedScopeProperties);
       setTypeMatcher(preparedTypeMatcher);
       setMethodMatcher(preparedMethodMatcher);
     }
@@ -148,7 +159,7 @@ const ScopeWizardDialog = ({ visible, onHide, onApply, scope }) => {
         label="Apply"
         disabled={isApplyDisabled}
         onClick={() => {
-          onApply(typeMatcher, methodMatcher);
+          onApply(scopeProperties, typeMatcher, methodMatcher);
           onHide();
         }}
       />
@@ -214,6 +225,7 @@ const ScopeWizardDialog = ({ visible, onHide, onApply, scope }) => {
           footer={footer}
           focusOnShow={false}
         >
+          <ScopeProps scopeProperties={scopeProperties} onScopePropsChange={setScopeProperties} />
           <TypeMatcher typeMatcher={typeMatcher} onTypeMatcherChange={setTypeMatcher} onShowClassBrowser={showClassBrowser} />
           <MethodMatcher methodMatcher={methodMatcher} onMethodMatcherChange={setMethodMatcher} />
         </Dialog>


### PR DESCRIPTION
Fields for scope properties like name and description are included in Wizard.

**ToDo:**
- Add scope properties to yaml content
- Adjust BE (Configurationserver) to save the new scope properties for future editing  _Necessary?_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/1494)
<!-- Reviewable:end -->
