### PR TITLE
Closes #1512: [Feature] - Update otel-collector image used in integration tests to latest

### DIFF
--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/ExporterServiceIntegrationTestBase.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/ExporterServiceIntegrationTestBase.java
@@ -62,7 +62,7 @@ abstract class ExporterServiceIntegrationTestBase extends SpringTestBase {
     static final String COLLECTOR_IMAGE = "otel/opentelemetry-collector-contrib:" + COLLECTOR_TAG;
 
     // This image was used previously.
-    //static final String COLLECTOR_IMAGE = "ghcr.io/open-telemetry/opentelemetry-java/otel-collector@sha256:d34519458388e55a3fce38a33e6bc424267c1f432927c09e932ba45f7575bd84"; //"otel/opentelemetry-collector";//
+    // static final String COLLECTOR_IMAGE = "ghcr.io/open-telemetry/opentelemetry-java/otel-collector@sha256:d34519458388e55a3fce38a33e6bc424267c1f432927c09e932ba45f7575bd84"; //"otel/opentelemetry-collector";//
 
     static final Integer COLLECTOR_OTLP_GRPC_PORT = 4317;
 
@@ -165,6 +165,17 @@ abstract class ExporterServiceIntegrationTestBase extends SpringTestBase {
      */
     static String getEndpoint(Integer originalPort, String path) {
         return String.format("http://%s:%d/%s", collector.getHost(), collector.getMappedPort(originalPort), path.startsWith("/") ? path.substring(1) : path);
+    }
+
+    /**
+     * Gets the desired endpoint of the {@link #collector} constructed as 'http://{@link GenericContainer#getHost() collector.getHost()}:{@link GenericContainer#getMappedPort(int) collector.getMappedPort(port)}'
+     *
+     * @param originalPort the port to get the actual mapped port for
+     *
+     * @return the constructed endpoint for the {@link #collector}
+     */
+    static String getEndpoint(Integer originalPort) {
+        return String.format("http://%s:%d", collector.getHost(), collector.getMappedPort(originalPort));
     }
 
     /**

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/ExporterServiceIntegrationTestBase.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/ExporterServiceIntegrationTestBase.java
@@ -61,9 +61,6 @@ abstract class ExporterServiceIntegrationTestBase extends SpringTestBase {
 
     static final String COLLECTOR_IMAGE = "otel/opentelemetry-collector-contrib:" + COLLECTOR_TAG;
 
-    // This image was used previously.
-    // static final String COLLECTOR_IMAGE = "ghcr.io/open-telemetry/opentelemetry-java/otel-collector@sha256:d34519458388e55a3fce38a33e6bc424267c1f432927c09e932ba45f7575bd84"; //"otel/opentelemetry-collector";//
-
     static final Integer COLLECTOR_OTLP_GRPC_PORT = 4317;
 
     static final Integer COLLECTOR_OTLP_HTTP_PORT = 4318;

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/ExporterServiceIntegrationTestBase.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/ExporterServiceIntegrationTestBase.java
@@ -57,7 +57,12 @@ import static org.testcontainers.Testcontainers.exposeHostPorts;
 @Testcontainers(disabledWithoutDocker = true)
 abstract class ExporterServiceIntegrationTestBase extends SpringTestBase {
 
-    static final String COLLECTOR_IMAGE = "ghcr.io/open-telemetry/opentelemetry-java/otel-collector@sha256:d34519458388e55a3fce38a33e6bc424267c1f432927c09e932ba45f7575bd84";
+    static final String COLLECTOR_TAG = "0.58.0";
+
+    static final String COLLECTOR_IMAGE = "otel/opentelemetry-collector-contrib:" + COLLECTOR_TAG;
+
+    // This image was used previously.
+    //static final String COLLECTOR_IMAGE = "ghcr.io/open-telemetry/opentelemetry-java/otel-collector@sha256:d34519458388e55a3fce38a33e6bc424267c1f432927c09e932ba45f7575bd84"; //"otel/opentelemetry-collector";//
 
     static final Integer COLLECTOR_OTLP_GRPC_PORT = 4317;
 
@@ -91,7 +96,7 @@ abstract class ExporterServiceIntegrationTestBase extends SpringTestBase {
     private static final Logger LOGGER = Logger.getLogger(ExporterServiceIntegrationTestBase.class.getName());
 
     /**
-     * The {@link OtlpGrpcServer} used as an exporter endpoirt for the OpenTelemetry Collector
+     * The {@link OtlpGrpcServer} used as an exporter endpoint for the OpenTelemetry Collector
      */
     static OtlpGrpcServer grpcServer;
 

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/OtlpMetricsExporterServiceIntTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/OtlpMetricsExporterServiceIntTest.java
@@ -51,7 +51,7 @@ public class OtlpMetricsExporterServiceIntTest extends ExporterServiceIntegratio
     @Test
     void verifyMetricsWrittenGrpc() {
         updateProperties(mps -> {
-            mps.setProperty("inspectit.exporters.metrics.otlp.endpoint", getEndpoint(COLLECTOR_OTLP_GRPC_PORT, OTLP_METRICS_PATH));
+            mps.setProperty("inspectit.exporters.metrics.otlp.endpoint", getEndpoint(COLLECTOR_OTLP_GRPC_PORT));
             mps.setProperty("inspectit.exporters.metrics.otlp.export-interval", "500ms");
             mps.setProperty("inspectit.exporters.metrics.otlp.enabled", ExporterEnabledState.ENABLED);
             mps.setProperty("inspectit.exporters.metrics.otlp.protocol", TransportProtocol.GRPC);

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/OtlpTraceExporterServiceIntTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/OtlpTraceExporterServiceIntTest.java
@@ -22,7 +22,7 @@ import static org.awaitility.Awaitility.await;
 @DirtiesContext
 public class OtlpTraceExporterServiceIntTest extends ExporterServiceIntegrationTestBase {
 
-    public static final String OTLP_GRPC_TRACING_PATH = "/v1/trace";
+    public static final String OTLP_TRACING_PATH = "/v1/traces";
 
     @RegisterExtension
     LogCapturer warnLogs = LogCapturer.create()
@@ -41,7 +41,7 @@ public class OtlpTraceExporterServiceIntTest extends ExporterServiceIntegrationT
     void verifyTraceSentGrpc() {
         updateProperties(properties -> {
             properties.setProperty("inspectit.exporters.tracing.otlp.protocol", TransportProtocol.GRPC);
-            properties.setProperty("inspectit.exporters.tracing.otlp.endpoint", getEndpoint(COLLECTOR_OTLP_GRPC_PORT, OTLP_GRPC_TRACING_PATH));
+            properties.setProperty("inspectit.exporters.tracing.otlp.endpoint", getEndpoint(COLLECTOR_OTLP_GRPC_PORT));
             properties.setProperty("inspectit.exporters.tracing.otlp.enabled", ExporterEnabledState.ENABLED);
         });
 
@@ -59,7 +59,7 @@ public class OtlpTraceExporterServiceIntTest extends ExporterServiceIntegrationT
     void verifyTraceSentHttp() {
         updateProperties(properties -> {
             properties.setProperty("inspectit.exporters.tracing.otlp.protocol", TransportProtocol.HTTP_PROTOBUF);
-            properties.setProperty("inspectit.exporters.tracing.otlp.endpoint", getEndpoint(COLLECTOR_OTLP_HTTP_PORT, OTLP_GRPC_TRACING_PATH));
+            properties.setProperty("inspectit.exporters.tracing.otlp.endpoint", getEndpoint(COLLECTOR_OTLP_HTTP_PORT, OTLP_TRACING_PATH));
             properties.setProperty("inspectit.exporters.tracing.otlp.enabled", ExporterEnabledState.ENABLED);
         });
 

--- a/inspectit-ocelot-core/src/test/resources/otel-config.yaml
+++ b/inspectit-ocelot-core/src/test/resources/otel-config.yaml
@@ -38,6 +38,8 @@ exporters:
     endpoint: $OTLP_EXPORTER_ENDPOINT
     tls:
       insecure: true
+    compression: none
+
 service:
   extensions: [health_check]
   pipelines:
@@ -50,3 +52,6 @@ service:
     logs:
       receivers: [otlp]
       exporters: [logging, otlp]
+  telemetry:
+    logs:
+      level: "info"


### PR DESCRIPTION
Closes #1512 

Upgrade the image used for the OpenTelemetry Collector (contrib) in the exporter integration tests.

* upgrade the otelcol-contrib image
* set compression to `none` in the otlp exporter defined in otel-colfig.yaml (from v0.44.0 to v0.45.0, the default compression of the otlp exporter of the OpenTelemetry Collector was changed to `gzip`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/1514)
<!-- Reviewable:end -->
