### PR TITLE
Closes #1534 and #1536 - Otlp*ExporterService does not expose underlying OTEL  configuration

### DIFF
--- a/inspectit-ocelot-config/build.gradle
+++ b/inspectit-ocelot-config/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     // the api is included as compile only because the open census api has to be decoupled
     // from the inspectIT core to allow it to be pushed to the bootstrap
     compileOnly (
-            "io.opencensus:opencensus-api:${openCensusVersion}"
+            "io.opencensus:opencensus-api:${openCensusVersion}",
+            // OpenTelemetry
+            platform("io.opentelemetry:opentelemetry-bom-alpha:${openTelemetryAlphaVersion}"),
+            "io.opentelemetry:opentelemetry-sdk-metrics",
     )
 }

--- a/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/exporters/CompressionMethod.java
+++ b/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/exporters/CompressionMethod.java
@@ -1,0 +1,13 @@
+package rocks.inspectit.ocelot.config.model.exporters;
+
+/**
+ * The compression method used in OTLP exporters.
+ */
+public enum CompressionMethod {
+    GZIP, NONE;
+
+    @Override
+    public String toString() {
+        return this.name().toLowerCase();
+    }
+}

--- a/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/exporters/metrics/OtlpMetricsExporterSettings.java
+++ b/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/exporters/metrics/OtlpMetricsExporterSettings.java
@@ -34,4 +34,9 @@ public class OtlpMetricsExporterSettings {
     @DurationMin(millis = 1)
     private Duration exportInterval;
 
+    /**
+     * The time period over which metrics should be aggregated.
+     * Valid values are CUMULATIVE and DELTA
+     */
+    private String preferredTemporality;
 }

--- a/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/exporters/metrics/OtlpMetricsExporterSettings.java
+++ b/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/exporters/metrics/OtlpMetricsExporterSettings.java
@@ -1,12 +1,15 @@
 package rocks.inspectit.ocelot.config.model.exporters.metrics;
 
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.time.DurationMin;
+import rocks.inspectit.ocelot.config.model.exporters.CompressionMethod;
 import rocks.inspectit.ocelot.config.model.exporters.ExporterEnabledState;
 import rocks.inspectit.ocelot.config.model.exporters.TransportProtocol;
 
 import java.time.Duration;
+import java.util.Map;
 
 /**
  * Settings for {@link rocks.inspectit.ocelot.core.exporter.OtlpMetricsExporterService}
@@ -38,5 +41,22 @@ public class OtlpMetricsExporterSettings {
      * The time period over which metrics should be aggregated.
      * Valid values are CUMULATIVE and DELTA
      */
-    private String preferredTemporality;
+    private AggregationTemporality preferredTemporality;
+
+    /**
+     * Key-value pairs to be used as headers associated with gRPC or HTTP requests.
+     */
+    private Map<String, String> headers;
+
+
+    /**
+     * The compression method.
+     */
+    private CompressionMethod compression;
+
+    /**
+     * Maximum time the OTLP exporter will wait for each batch export.
+     */
+    @DurationMin(millis = 1)
+    private Duration timeout;
 }

--- a/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/exporters/trace/OtlpTraceExporterSettings.java
+++ b/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/exporters/trace/OtlpTraceExporterSettings.java
@@ -2,8 +2,13 @@ package rocks.inspectit.ocelot.config.model.exporters.trace;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.time.DurationMin;
+import rocks.inspectit.ocelot.config.model.exporters.CompressionMethod;
 import rocks.inspectit.ocelot.config.model.exporters.ExporterEnabledState;
 import rocks.inspectit.ocelot.config.model.exporters.TransportProtocol;
+
+import java.time.Duration;
+import java.util.Map;
 
 /**
  * Settings for {@link rocks.inspectit.ocelot.core.exporter.OtlpTraceExporterService}
@@ -25,4 +30,19 @@ public class OtlpTraceExporterSettings {
      */
     private TransportProtocol protocol;
 
+    /**
+     * Key-value pairs to be used as headers associated with gRPC or HTTP requests.
+     */
+    private Map<String, String> headers;
+
+    /**
+     * The compression method.
+     */
+    private CompressionMethod compression;
+
+    /**
+     * Maximum time the OTLP exporter will wait for each batch export.
+     */
+    @DurationMin(millis = 1)
+    private Duration timeout;
 }

--- a/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/exporters.yml
+++ b/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/exporters.yml
@@ -53,6 +53,14 @@ inspectit:
         endpoint: null
         # the transport protocol, e.g., 'grpc' or 'http/protobuf'
         protocol:
+        # headers
+        headers: {}
+        # the aggregation temporality, e.g., CUMULATIVE or DELTA
+        preferredTemporality: CUMULATIVE
+        # compression method
+        compression: NONE
+        # timeout, i.e., maximum time the OTLP exporter will wait for each batch export
+        timeout: 10s
 
     # settings for trace exporters
     tracing:
@@ -85,3 +93,9 @@ inspectit:
         endpoint: null
         # the transport protocol, e.g., 'http/thrift' or 'grpc'
         protocol:
+        # headers
+        headers: {}
+        # compression method
+        compression: NONE
+        # timeout, i.e., maximum time the OTLP exporter will wait for each batch export
+        timeout: 10s

--- a/inspectit-ocelot-core/build.gradle
+++ b/inspectit-ocelot-core/build.gradle
@@ -133,8 +133,8 @@ dependencies {
             'io.apisense.embed.influx:embed-influxDB:1.2.1',
 
             // for docker test containers
-            'org.testcontainers:testcontainers:1.15.2',
-            'org.testcontainers:junit-jupiter:1.15.2',
+            'org.testcontainers:testcontainers:1.16.3',
+            'org.testcontainers:junit-jupiter:1.16.3',
 
             // ServerExtension
             'com.linecorp.armeria:armeria-junit5:1.14.1',

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/exporter/OtlpMetricsExporterService.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/exporter/OtlpMetricsExporterService.java
@@ -1,7 +1,10 @@
 package rocks.inspectit.ocelot.core.exporter;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.metrics.export.MetricReaderFactory;
@@ -18,6 +21,7 @@ import rocks.inspectit.ocelot.config.model.exporters.metrics.OtlpMetricsExporter
 import javax.validation.Valid;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Service for {@link io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter}/{@link io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter}.
@@ -29,10 +33,11 @@ public class OtlpMetricsExporterService extends DynamicallyActivatableMetricsExp
 
     private final List<TransportProtocol> SUPPORTED_PROTOCOLS = Arrays.asList(TransportProtocol.GRPC, TransportProtocol.HTTP_PROTOBUF);
 
+    @VisibleForTesting
     /**
      * The {@link MetricExporter} for exporting metrics via OTLP
      */
-    private MetricExporter metricExporter;
+    MetricExporter metricExporter;
 
     /**
      * The {@link PeriodicMetricReaderBuilder} for reading metrics to the log
@@ -76,19 +81,33 @@ public class OtlpMetricsExporterService extends DynamicallyActivatableMetricsExp
         try {
             OtlpMetricsExporterSettings otlp = configuration.getExporters().getMetrics().getOtlp();
 
-            AggregationTemporality preferredTemporality = getPreferredTemporality(otlp);
+            AggregationTemporality preferredTemporality = otlp.getPreferredTemporality();
 
             switch (otlp.getProtocol()) {
                 case GRPC: {
-                    metricExporter = OtlpGrpcMetricExporter.builder()
+                    OtlpGrpcMetricExporterBuilder metricExporterBuilder = OtlpGrpcMetricExporter.builder()
                             .setPreferredTemporality(preferredTemporality)
-                            .setEndpoint(otlp.getEndpoint()).build();
+                            .setEndpoint(otlp.getEndpoint()).setCompression(otlp.getCompression().toString())
+                            .setTimeout(otlp.getTimeout());
+                    if (otlp.getHeaders() != null) {
+                        for (Map.Entry<String, String> headerEntry : otlp.getHeaders().entrySet()) {
+                            metricExporterBuilder.addHeader(headerEntry.getKey(), headerEntry.getValue());
+                        }
+                    }
+                    metricExporter = metricExporterBuilder.build();
                     break;
                 }
                 case HTTP_PROTOBUF: {
-                    metricExporter = OtlpHttpMetricExporter.builder()
+                    OtlpHttpMetricExporterBuilder metricExporterBuilder = OtlpHttpMetricExporter.builder()
                             .setPreferredTemporality(preferredTemporality)
-                            .setEndpoint(otlp.getEndpoint()).build();
+                            .setEndpoint(otlp.getEndpoint()).setCompression(otlp.getCompression().toString())
+                            .setTimeout(otlp.getTimeout());
+                    if (otlp.getHeaders() != null) {
+                        for (Map.Entry<String, String> headerEntry : otlp.getHeaders().entrySet()) {
+                            metricExporterBuilder.addHeader(headerEntry.getKey(), headerEntry.getValue());
+                        }
+                    }
+                    metricExporter = metricExporterBuilder.build();
                     break;
                 }
             }
@@ -102,21 +121,9 @@ public class OtlpMetricsExporterService extends DynamicallyActivatableMetricsExp
             }
             return success;
         } catch (Exception e) {
-            log.error("Error creatig OTLP metrics exporter service", e);
+            log.error("Error creating OTLP metrics exporter service", e);
             return false;
         }
-    }
-
-    private static AggregationTemporality getPreferredTemporality(OtlpMetricsExporterSettings otlp) {
-        AggregationTemporality preferredTemporality;
-        try {
-           preferredTemporality = AggregationTemporality.valueOf(otlp.getPreferredTemporality());
-        }
-        catch ( IllegalArgumentException e) {
-            preferredTemporality = AggregationTemporality.CUMULATIVE;
-            log.warn("Unable to set preferred Temporality of value {}. Falling back to {}. Valid values are {}", otlp.getPreferredTemporality(), preferredTemporality, AggregationTemporality.values());
-        }
-        return preferredTemporality;
     }
 
     @Override

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/exporter/OtlpMetricsExporterService.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/exporter/OtlpMetricsExporterService.java
@@ -114,7 +114,7 @@ public class OtlpMetricsExporterService extends DynamicallyActivatableMetricsExp
         }
         catch ( IllegalArgumentException e) {
             preferredTemporality = AggregationTemporality.CUMULATIVE;
-            log.error("Unable to set preferred Temporality of value {}. Falling back to {}. Valid values are {}", otlp.getPreferredTemporality(), preferredTemporality, AggregationTemporality.values());
+            log.warn("Unable to set preferred Temporality of value {}. Falling back to {}. Valid values are {}", otlp.getPreferredTemporality(), preferredTemporality, AggregationTemporality.values());
         }
         return preferredTemporality;
     }

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/exporter/OtlpTraceExporterService.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/exporter/OtlpTraceExporterService.java
@@ -1,7 +1,9 @@
 package rocks.inspectit.ocelot.core.exporter;
 
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +18,7 @@ import rocks.inspectit.ocelot.core.service.DynamicallyActivatableService;
 import javax.validation.Valid;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Service for {@link io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter}/{@link io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter}.
@@ -62,11 +65,26 @@ public class OtlpTraceExporterService extends DynamicallyActivatableService {
 
             switch (otlp.getProtocol()) {
                 case GRPC: {
-                    spanExporter = OtlpGrpcSpanExporter.builder().setEndpoint(otlp.getEndpoint()).build();
+                    OtlpGrpcSpanExporterBuilder otlpGrpcSpanExporterBuilder =OtlpGrpcSpanExporter.builder().setEndpoint(otlp.getEndpoint())
+                            .setCompression(otlp.getCompression().toString())
+                            .setTimeout(otlp.getTimeout());
+                    if(otlp.getHeaders() != null){
+                        for (Map.Entry<String, String> headerEntry : otlp.getHeaders().entrySet()) {
+                            otlpGrpcSpanExporterBuilder.addHeader(headerEntry.getKey(), headerEntry.getValue());
+                        }
+                    }
+                    spanExporter = otlpGrpcSpanExporterBuilder.build();
                     break;
                 }
                 case HTTP_PROTOBUF: {
-                    spanExporter = OtlpHttpSpanExporter.builder().setEndpoint(otlp.getEndpoint()).build();
+                    OtlpHttpSpanExporterBuilder otlpHttpSpanExporterBuilder =OtlpHttpSpanExporter.builder().setEndpoint(otlp.getEndpoint()).setCompression(otlp.getCompression().toString())
+                            .setTimeout(otlp.getTimeout());
+                    if(otlp.getHeaders() != null){
+                        for (Map.Entry<String, String> headerEntry : otlp.getHeaders().entrySet()) {
+                            otlpHttpSpanExporterBuilder.addHeader(headerEntry.getKey(), headerEntry.getValue());
+                        }
+                    }
+                    spanExporter = otlpHttpSpanExporterBuilder.build();
                     break;
                 }
             }

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/OtlpMetricsExporterServiceIntTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/OtlpMetricsExporterServiceIntTest.java
@@ -87,6 +87,15 @@ public class OtlpMetricsExporterServiceIntTest extends ExporterServiceIntegratio
 
     @DirtiesContext
     @Test
+    void invalidPreferredTemporalitySet() {
+        updateProperties(props -> {
+            props.setProperty("inspectit.exporters.metrics.otlp.preferredTemporality", "invalid");
+        });
+        warnLogs.assertContains("'preferredTemporality'");
+    }
+
+    @DirtiesContext
+    @Test
     void testNoEndpointSet() {
         updateProperties(props -> {
             props.setProperty("inspectit.exporters.metrics.otlp.endpoint", "");

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/OtlpMetricsExporterServiceIntTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/OtlpMetricsExporterServiceIntTest.java
@@ -1,17 +1,22 @@
 package rocks.inspectit.ocelot.core.exporter;
 
 import io.github.netmikey.logunit.api.LogCapturer;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
+import rocks.inspectit.ocelot.config.model.exporters.CompressionMethod;
 import rocks.inspectit.ocelot.config.model.exporters.ExporterEnabledState;
 import rocks.inspectit.ocelot.config.model.exporters.TransportProtocol;
 import rocks.inspectit.ocelot.config.model.exporters.metrics.OtlpMetricsExporterSettings;
 import rocks.inspectit.ocelot.core.config.InspectitEnvironment;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -85,17 +90,7 @@ public class OtlpMetricsExporterServiceIntTest extends ExporterServiceIntegratio
         awaitMetricsExported(metricVal, tagKeyHttp, tagVal);
     }
 
-    @DirtiesContext
-    @Test
-    void invalidPreferredTemporalitySet() {
-        updateProperties(props -> {
-            props.setProperty("inspectit.exporters.metrics.otlp.enabled", ExporterEnabledState.ENABLED);
-            props.setProperty("inspectit.exporters.metrics.otlp.endpoint", getEndpoint(COLLECTOR_OTLP_GRPC_PORT));
-            props.setProperty("inspectit.exporters.metrics.otlp.protocol", TransportProtocol.GRPC);
-            props.setProperty("inspectit.exporters.metrics.otlp.preferredTemporality", "invalid");
-        });
-        warnLogs.assertContains("invalid");
-    }
+
 
     @DirtiesContext
     @Test
@@ -125,5 +120,101 @@ public class OtlpMetricsExporterServiceIntTest extends ExporterServiceIntegratio
         assertThat(otlp.getEnabled().equals(ExporterEnabledState.IF_CONFIGURED));
         assertThat(otlp.getEndpoint()).isNullOrEmpty();
         assertThat(otlp.getProtocol()).isNull();
+        assertThat(otlp.getPreferredTemporality()).isEqualTo(AggregationTemporality.CUMULATIVE);
+        assertThat(otlp.getHeaders()).isNullOrEmpty();
+        assertThat(otlp.getCompression()).isEqualTo(CompressionMethod.NONE);
+        assertThat(otlp.getTimeout()).isEqualTo(Duration.ofSeconds(10));
+    }
+
+    @DirtiesContext
+    @Test
+    void testAggregationTemporalityCumulative(){
+        updateProperties(mps -> {
+            mps.setProperty("inspectit.exporters.metrics.otlp.endpoint", getEndpoint(COLLECTOR_OTLP_GRPC_PORT));
+            mps.setProperty("inspectit.exporters.metrics.otlp.export-interval", "500ms");
+            mps.setProperty("inspectit.exporters.metrics.otlp.enabled", ExporterEnabledState.ENABLED);
+            mps.setProperty("inspectit.exporters.metrics.otlp.protocol", TransportProtocol.GRPC);
+            mps.setProperty("inspectit.exporters.metrics.otlp.preferredTemporality", AggregationTemporality.CUMULATIVE);
+        });
+
+        assertThat(service.isEnabled()).isTrue();
+
+        recordMetricsAndFlush(1, "key", "val");
+        recordMetricsAndFlush(2, "key", "val");
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(grpcServer.metricRequests.stream()).anyMatch(mReq -> mReq.getResourceMetricsList()
+                        .stream()
+                        .anyMatch(rm ->
+                                // check for the "my-counter" metrics
+                                rm.getInstrumentationLibraryMetrics(0).getMetrics(0).getName().equals("my-counter")
+                                        // check for the specific attribute and value
+                                        && rm.getInstrumentationLibraryMetrics(0)
+                                        .getMetricsList()
+                                        .stream()
+                                        .anyMatch(metric -> metric.getSum()
+                                                .getDataPointsList()
+                                                .stream()
+                                                .anyMatch(d -> d.getAsInt() == 3)))));
+    }
+
+    @DirtiesContext
+    @Test
+    void testAggregationTemporalityDelta(){
+        updateProperties(mps -> {
+            mps.setProperty("inspectit.exporters.metrics.otlp.endpoint", getEndpoint(COLLECTOR_OTLP_GRPC_PORT));
+            mps.setProperty("inspectit.exporters.metrics.otlp.export-interval", "500ms");
+            mps.setProperty("inspectit.exporters.metrics.otlp.enabled", ExporterEnabledState.ENABLED);
+            mps.setProperty("inspectit.exporters.metrics.otlp.protocol", TransportProtocol.GRPC);
+            mps.setProperty("inspectit.exporters.metrics.otlp.preferredTemporality", AggregationTemporality.DELTA);
+        });
+
+        assertThat(service.isEnabled()).isTrue();
+
+        recordMetricsAndFlush(1, "key", "val");
+        recordMetricsAndFlush(2, "key", "val");
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(grpcServer.metricRequests.stream()).anyMatch(mReq -> mReq.getResourceMetricsList()
+                        .stream()
+                        .anyMatch(rm ->
+                                // check for the "my-counter" metrics
+                                rm.getInstrumentationLibraryMetrics(0).getMetrics(0).getName().equals("my-counter")
+                                        // check for the specific attribute and value
+                                        && rm.getInstrumentationLibraryMetrics(0)
+                                        .getMetricsList()
+                                        .stream()
+                                        .anyMatch(metric -> metric.getSum()
+                                                .getDataPointsList()
+                                                .stream()
+                                                .anyMatch(d -> d.getAsInt() == 2)))));
+
+    }
+
+    @DirtiesContext
+    @Test
+    void testHeaders(){
+        updateProperties(mps -> {
+            mps.setProperty("inspectit.exporters.metrics.otlp.endpoint", getEndpoint(COLLECTOR_OTLP_GRPC_PORT));
+            mps.setProperty("inspectit.exporters.metrics.otlp.export-interval", "500ms");
+            mps.setProperty("inspectit.exporters.metrics.otlp.enabled", ExporterEnabledState.ENABLED);
+            mps.setProperty("inspectit.exporters.metrics.otlp.protocol", TransportProtocol.GRPC);
+            mps.setProperty("inspectit.exporters.metrics.otlp.headers", new HashMap<String, String>(){{put("my-header-key","my-header-value");}});
+        });
+        assertThat(service.isEnabled()).isTrue();
+        assertThat(environment.getCurrentConfig().getExporters().getMetrics().getOtlp().getHeaders()).containsEntry("my-header-key","my-header-value");
+    }
+
+    @DirtiesContext
+    @Test
+    void testCompression() {
+        updateProperties(properties -> {
+            properties.setProperty("inspectit.exporters.metrics.otlp.protocol", TransportProtocol.GRPC);
+            properties.setProperty("inspectit.exporters.metrics.otlp.endpoint", getEndpoint(COLLECTOR_OTLP_GRPC_PORT));
+            properties.setProperty("inspectit.exporters.metrics.otlp.enabled", ExporterEnabledState.ENABLED);
+            properties.setProperty("inspectit.exporters.metrics.otlp.compression", CompressionMethod.GZIP);
+        });
+        assertThat(service.isEnabled()).isTrue();
+        assertThat(environment.getCurrentConfig().getExporters().getMetrics().getOtlp().getCompression()).isEqualTo(CompressionMethod.GZIP);
     }
 }

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/OtlpMetricsExporterServiceIntTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/exporter/OtlpMetricsExporterServiceIntTest.java
@@ -89,9 +89,12 @@ public class OtlpMetricsExporterServiceIntTest extends ExporterServiceIntegratio
     @Test
     void invalidPreferredTemporalitySet() {
         updateProperties(props -> {
+            props.setProperty("inspectit.exporters.metrics.otlp.enabled", ExporterEnabledState.ENABLED);
+            props.setProperty("inspectit.exporters.metrics.otlp.endpoint", getEndpoint(COLLECTOR_OTLP_GRPC_PORT));
+            props.setProperty("inspectit.exporters.metrics.otlp.protocol", TransportProtocol.GRPC);
             props.setProperty("inspectit.exporters.metrics.otlp.preferredTemporality", "invalid");
         });
-        warnLogs.assertContains("'preferredTemporality'");
+        warnLogs.assertContains("invalid");
     }
 
     @DirtiesContext

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/opentelemetry/OpenTelemetryControllerImplIntTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/opentelemetry/OpenTelemetryControllerImplIntTest.java
@@ -18,13 +18,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import rocks.inspectit.ocelot.config.model.exporters.ExporterEnabledState;
 import rocks.inspectit.ocelot.core.SLF4JBridgeHandlerUtils;
 import rocks.inspectit.ocelot.core.SpringTestBase;
 import rocks.inspectit.ocelot.core.exporter.LoggingTraceExporterService;
-import rocks.inspectit.ocelot.core.opentelemetry.trace.CustomIdGenerator;
 import rocks.inspectit.ocelot.core.utils.OpenTelemetryUtils;
 
 import java.io.IOException;

--- a/inspectit-ocelot-documentation/docs/metrics/metric-exporters.md
+++ b/inspectit-ocelot-documentation/docs/metrics/metric-exporters.md
@@ -82,11 +82,15 @@ To enable the OTLP exporters, it is only required to specify the `url`.
 
 The following properties are nested properties below the `inspectit.exporters.metrics.otlp-grpc` property:
 
-| Property    | Default         | Description                                                                                                                                                                     |
-| ----------- |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `.enabled`  | `IF_CONFIGURED` | If `ENABLED` or `IF_CONFIGURED`, the inspectIT Ocelot agent will try to start the OTLP gRPC metrics exporter.                                                                   |
-| `.endpoint` | `null`          | Target to which the exporter is going to send metrics, e.g. `http://localhost:4317`                                                                                             |
-| `.protocol` | `null`          | The transport protocol, see [OTEL documentation](https://opentelemetry.io/docs/reference/specification/protocol/exporter/). Supported protocols are `grpc` and `http/protobuf`. |
+| Property                | Default         | Description                                                                                                                                                                                                                  |
+|-------------------------|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `.enabled`              | `IF_CONFIGURED` | If `ENABLED` or `IF_CONFIGURED`, the inspectIT Ocelot agent will try to start the OTLP gRPC metrics exporter.                                                                                                                |
+| `.endpoint`             | `null`          | Target to which the exporter is going to send metrics, e.g. `http://localhost:4317`                                                                                                                                          |
+| `.protocol`             | `null`          | The transport protocol, see [OTEL documentation](https://opentelemetry.io/docs/reference/specification/protocol/exporter/). Supported protocols are `grpc` and `http/protobuf`.                                              |
+| `.preferredTemporality` | `CUMULATIVE`    | The preferred output aggregation temporality, see [OTEL documentation](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md). Supported values are `CUMULATIVE` and `DELTA`.| 
+| `.headers`              | `null`          | Key-value pairs to be used as headers associated with gRPC or HTTP requests, see [OTEL documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md).|
+| `.compression` | `NONE`          | The compression method, see [OTEL documentation](https://opentelemetry.io/docs/reference/specification/protocol/exporter/). Supported compression methods are `gzip` and `none`.                                   |
+| `.timeout`     | `10s`           | Maximum time the OTLP exporter will wait for each batch export, see [OTEL documentation](https://opentelemetry.io/docs/reference/specification/protocol/exporter/).                           |
 
 To make inspectIT Ocelot push the metris via OTLP to, e.g. an OpenTelemetry Collector running on the same machine as the agent, the following JVM property can be used:
 

--- a/inspectit-ocelot-documentation/docs/tracing/trace-exporters.md
+++ b/inspectit-ocelot-documentation/docs/tracing/trace-exporters.md
@@ -84,11 +84,14 @@ By default, the OTLP exporters are enabled but the URL endpoint needed for the e
 
 The following properties are nested properties below the `inspectit.exporters.tracing.otlp` property:
 
-| Property    | Default    | Description                                                                                                                                                                     |
-| ----------- |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `.enabled`  | `IF_CONFIGURED` | If `ENABLED` or `IF_CONFIGURED`, the inspectIT Ocelot agent will try to start the OTLP gRPC trace exporter.                                                                     |
-| `.endpoint` | `null`     | Target to which the exporter is going to send traces, e.g. `http://localhost:4317`                                                                                              |
-| `.protocol` | `null`     | The transport protocol, see [OTEL documentation](https://opentelemetry.io/docs/reference/specification/protocol/exporter/). Supported protocols are `grpc` and `http/protobuf`. |
+| Property       | Default         | Description                                                                                                                                                                                                        |
+|----------------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `.enabled`     | `IF_CONFIGURED` | If `ENABLED` or `IF_CONFIGURED`, the inspectIT Ocelot agent will try to start the OTLP gRPC trace exporter.                                                                                                        |
+| `.endpoint`    | `null`          | Target to which the exporter is going to send traces, e.g. `http://localhost:4317`                                                                                                                                 |
+| `.protocol`    | `null`          | The transport protocol, see [OTEL documentation](https://opentelemetry.io/docs/reference/specification/protocol/exporter/). Supported protocols are `grpc` and `http/protobuf`.                                    |
+| `.headers`     | `null`          | Key-value pairs to be used as headers associated with gRPC or HTTP requests, see [OTEL documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md). |
+| `.compression` | `NONE`          | The compression method, see [OTEL documentation](https://opentelemetry.io/docs/reference/specification/protocol/exporter/). Supported compression methods are `gzip` and `none`.                                   |
+| `.timeout`     | `10s`           | Maximum time the OTLP exporter will wait for each batch export, see [OTEL documentation](https://opentelemetry.io/docs/reference/specification/protocol/exporter/).                           |
 
 To make inspectIT Ocelot push the spans via OTLP to, e.g. an OpenTelemetry Collector running on the same machine as the agent, the following JVM property can be used:
 


### PR DESCRIPTION
Closes #1534 and #1536

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit-ocelot/1536)
<!-- Reviewable:end -->
