### PR TITLE
Add missing dependency to configdocsgenerator

### DIFF
--- a/components/inspectit-ocelot-configdocsgenerator/build.gradle
+++ b/components/inspectit-ocelot-configdocsgenerator/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     testImplementation(
             'org.junit.jupiter:junit-jupiter',
             "io.opencensus:opencensus-api:${openCensusVersion}",
+            "io.opentelemetry:opentelemetry-api:${openTelemetryVersion}",
+
             'org.mockito:mockito-junit-jupiter',
             "org.assertj:assertj-core",
             'com.google.guava:guava:31.1-jre'


### PR DESCRIPTION
The configdocsgenerator was missing OpenTelemetry dependencies, see https://github.com/inspectIT/inspectit-ocelot/actions/runs/3997231832/jobs/6858288326

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectIT/inspectit-ocelot/1567)
<!-- Reviewable:end -->
