### PR TITLE
Increase time out for generating GitHub Pages in CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ jobs:
       - attach_repo
       - run:
           name: Deploying to GitHub Pages
+          no_output_timeout: 20m
           working_directory: ~/inspectit/repo/inspectit-ocelot-documentation/website
           command: |
             git config --global user.email "NTTechnicalUser@users.noreply.github.com"
@@ -179,6 +180,11 @@ jobs:
             git add versions.json versioned_docs versioned_sidebars
             git commit -m "[skip ci] Publish documentation v${CIRCLE_TAG}"
             git push
+      - run:
+          name: Deploying to GitHub Pages
+          no_output_timeout: 20m
+          working_directory: ~/inspectit/inspectit-ocelot-documentation/website
+          command: |
             GIT_USER=NTTechnicalUser CUSTOM_COMMIT_MESSAGE="[skip ci] Publish documentation v${CIRCLE_TAG}" npm run publish-gh-pages
 
 # ###############################################


### PR DESCRIPTION
This PR increase the timeout for generating GitHub Pages in CircleCi and moves this action into a separate step, so that a failure in this step does not block the entire workflow

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectIT/inspectit-ocelot/1570)
<!-- Reviewable:end -->
