### PR TITLE
Closes #1597: [Bug] - CRITICAL: Deadlock AgentHealthManager and failing instrumentation

### DIFF
--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/selfmonitoring/AgentHealthManagerDeadlockGh1597IntTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/selfmonitoring/AgentHealthManagerDeadlockGh1597IntTest.java
@@ -1,0 +1,69 @@
+package rocks.inspectit.ocelot.core.selfmonitoring;
+
+import org.awaitility.Awaitility;
+import org.checkerframework.checker.units.qual.A;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import rocks.inspectit.ocelot.core.SpringTestBase;
+import rocks.inspectit.ocelot.core.logging.logback.LogbackInitializer;
+
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Regression test for <a href="https://github.com/inspectIT/inspectit-ocelot/issues/1597">Github issue 1597</a>.
+ */
+@DirtiesContext
+public class AgentHealthManagerDeadlockGh1597IntTest extends SpringTestBase {
+
+    private static final Logger logger = LoggerFactory.getLogger("test-logger");
+
+    @Autowired
+    private AgentHealthManager cut;
+
+    @Test
+    void testLogging() throws Exception {
+        // This installs InternalProcessingAppender which together with AgentHealthManager caused a deadlock
+        LogbackInitializer.initDefaultLogging();
+
+        int millisToRun = 500;
+        Thread logThread = new Thread(() -> {
+            long start = System.currentTimeMillis();
+            boolean shouldLogError = true;
+            while (System.currentTimeMillis() - start < millisToRun) {
+                if (shouldLogError) {
+                    logger.error("Reporting an error");
+                    shouldLogError = false;
+                } else {
+                    logger.info("Reporting an info");
+                    shouldLogError = true;
+                }
+
+            }
+        });
+
+        AtomicBoolean isInvalidationThreadDone = new AtomicBoolean(false);
+
+        Thread invalidationThread = new Thread(() -> {
+            long start = System.currentTimeMillis();
+            while (System.currentTimeMillis() - start < millisToRun) {
+                cut.onInvalidationEvent(cut.getClass());
+            }
+            isInvalidationThreadDone.getAndSet(true);
+        });
+
+        // letting those two threads run for a while caused the deadlock on the developers machine before the fix.
+        // This is far from an ideal test, but the best we came up with.
+        logThread.start();
+        invalidationThread.start();
+
+        Awaitility.waitAtMost(millisToRun * 2, TimeUnit.MILLISECONDS).until(isInvalidationThreadDone::get);
+    }
+
+}


### PR DESCRIPTION
There could have been a deadlock if AgentHealthManager is invalidated while a change in Health is happening from different threads. Details see https://github.com/inspectIT/inspectit-ocelot/issues/1597

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectIT/inspectit-ocelot/1599)
<!-- Reviewable:end -->
