### PR TITLE
Delays start of inspectit for a configurable amount of time

### DIFF
--- a/inspectit-ocelot-bootstrap/src/main/java/rocks/inspectit/ocelot/bootstrap/IAgent.java
+++ b/inspectit-ocelot-bootstrap/src/main/java/rocks/inspectit/ocelot/bootstrap/IAgent.java
@@ -4,7 +4,7 @@ import java.lang.instrument.Instrumentation;
 
 /**
  * Controller interface for the Agent. Its implementation is {@link rocks.inspectit.ocelot.core.AgentImpl}.
- * The implementation must provide a default cosntructor without side effects!
+ * The implementation must provide a default constructor without side effects!
  * The actual initialization should happen in {@link #start(String, Instrumentation)}, which is called by {@link AgentManager}
  */
 public interface IAgent {

--- a/inspectit-ocelot-documentation/docs/instrumentation/process.md
+++ b/inspectit-ocelot-documentation/docs/instrumentation/process.md
@@ -62,3 +62,35 @@ inspectit:
       async: false
 ```
 
+## Delayed instrumentation
+Despite instrumenting asynchronously or synchronously, inspectIT always starts the instrumentation process as soon as
+the agent is attached to a JVM. There are cases in which it is desirable to postpone the start of the instrumentation 
+process. Although this is rarely necessary inspectIT provides the possibility to do so via system property
+`inspectit.start.delay` or OS environment variable `INSPECTIT_START_DELAY`. 
+
+You provide a value interpreted as milliseconds the agent shall wait before the instrumentation process starts. If you 
+do not provide a value the instrumentation process will start immediately.
+
+The Agent expects positive integers excluding zero. For all other values the agent will print an error message on stderr
+and continue as if there was no value supplied.
+
+If you specify both system property and OS environment variable, the system property will take precedence.
+
+Since this option has an impact before the agent fetches any configuration from the
+[Configuration Server](config-server/overview.md) you cannot specify that value like any other inspectIT configuration
+property. It is only available as system property or OS environment variable.
+
+Example using system property:
+```bash
+# this will delay the instrumentation process by 10 minutes
+$ java -javaagent:"/path/to/inspectit-ocelot-agent-{inspectit-ocelot-version}.jar" \
+   -Dinspectit.start.delay=600000 \
+   -jar my-java-program.jar
+```
+
+Example using OS environment variable (using bash):
+```bash
+# this will delay the instrumentation process by 5 minutes
+$ export INSPECTIT_START_DELAY=300000
+$ java -javaagent:"/path/to/inspectit-ocelot-agent-{inspectit-ocelot-version}.jar" -jar my-java-program.jar
+```


### PR DESCRIPTION
This property is rarely useful. There are cases you want to start an application with inspectit's agent attached but inspectit should pick up its work only after a configurable amount of milliseconds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectIT/inspectit-ocelot/1606)
<!-- Reviewable:end -->
