### PR TITLE
fix agent error status by increasing the agent command timeout

### DIFF
--- a/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/config/model/AgentCommandSettings.java
+++ b/components/inspectit-ocelot-configurationserver/src/main/java/rocks/inspectit/ocelot/config/model/AgentCommandSettings.java
@@ -14,13 +14,15 @@ import java.time.Duration;
 public class AgentCommandSettings {
 
     /**
-     * Timeout for agent commands. After this duration, they will be removed if not fetched.
+     * Timeout for agent commands. After this duration, they will be removed if not
+     * fetched.
      */
     @Builder.Default
     private Duration commandTimeout = Duration.ofMinutes(2);
 
     /**
-     * Timeout how long a command will wait for a response from the agent before it will be removed.
+     * Timeout how long a command will wait for a response from the agent before it
+     * will be removed.
      */
     @Builder.Default
     private Duration responseTimeout = Duration.ofSeconds(30);
@@ -33,7 +35,9 @@ public class AgentCommandSettings {
 
     /**
      * The max. time an agent is allowed to wait for a new command.
+     * This value must be greater than the max response timeout from the config
+     * server.
      */
     @Builder.Default
-    private Duration agentPollingTimeout = Duration.ofSeconds(30);
+    private Duration agentPollingTimeout = Duration.ofSeconds(40);
 }

--- a/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/basics.yml
+++ b/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/basics.yml
@@ -121,7 +121,8 @@ inspectit:
     agent-command-path: "/api/v1/agent/command"
     # the timeout duration used when the agent is in discovery mode. Defining how long the agent
     # will wait for new commands.
-    live-socket-timeout: 30s
+    # This value must be greater than the max response timeout from the config server.
+    live-socket-timeout: 40s
     # the timeout duration used for requests when the agent is in normal mode
     socket-timeout: 5s
     # the used interval for polling commands


### PR DESCRIPTION
The timeout is set to the same value as on the server side, so there is no time left to receive the no content response.

Solution: add another 10s on the agent side to be able to receive the response.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectIT/inspectit-ocelot/1618)
<!-- Reviewable:end -->
