### PR TITLE
add down propagated data to late BrowserPropagationDataStorage

### DIFF
--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/instrumentation/context/InspectitContextImpl.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/instrumentation/context/InspectitContextImpl.java
@@ -477,10 +477,8 @@ public class InspectitContextImpl implements InternalInspectitContext {
         // Write browser propagation data to storage
         Map<String, Object> propagationData = getDataAsStream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         Map<String, Object> browserPropagationData = getBrowserPropagationData(propagationData);
-        if(browserPropagationDataStorage != null){
+        if(browserPropagationDataStorage != null)
             browserPropagationDataStorage.writeData(browserPropagationData);
-        }
-
 
         //If there is browser propagation data, but exporter is disabled, write error message
         if(!browserPropagationData.isEmpty() && !browserPropagationSessionStorage.isExporterActive())

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/instrumentation/context/InspectitContextImpl.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/instrumentation/context/InspectitContextImpl.java
@@ -17,6 +17,7 @@ import rocks.inspectit.ocelot.core.instrumentation.config.model.propagation.Prop
 import rocks.inspectit.ocelot.core.tags.TagUtils;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -474,9 +475,12 @@ public class InspectitContextImpl implements InternalInspectitContext {
         }
 
         // Write browser propagation data to storage
-        Map<String, Object> browserPropagationData = getBrowserPropagationData(dataOverwrites);
-        if(browserPropagationDataStorage != null)
+        Map<String, Object> propagationData = getDataAsStream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<String, Object> browserPropagationData = getBrowserPropagationData(propagationData);
+        if(browserPropagationDataStorage != null){
             browserPropagationDataStorage.writeData(browserPropagationData);
+        }
+
 
         //If there is browser propagation data, but exporter is disabled, write error message
         if(!browserPropagationData.isEmpty() && !browserPropagationSessionStorage.isExporterActive())

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/instrumentation/browser/BrowserPropagationDataStorageTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/instrumentation/browser/BrowserPropagationDataStorageTest.java
@@ -6,6 +6,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+import rocks.inspectit.ocelot.bootstrap.context.InternalInspectitContext;
 import rocks.inspectit.ocelot.core.SpringTestBase;
 import rocks.inspectit.ocelot.core.instrumentation.config.model.propagation.PropagationMetaData;
 import rocks.inspectit.ocelot.core.instrumentation.context.ContextUtil;
@@ -48,7 +49,6 @@ public class BrowserPropagationDataStorageTest extends SpringTestBase {
     void clearDataStorage() {
         sessionStorage.clearDataStorages();
     }
-
 
     @Nested
     public class WriteBrowserPropagationData {
@@ -95,6 +95,7 @@ public class BrowserPropagationDataStorageTest extends SpringTestBase {
             Map<String, Object> oldData = new HashMap<>();
             oldData.put("keyA", "value0");
             dataStorage.writeData(oldData);
+
             InspectitContextImpl ctxA = InspectitContextImpl.createFromCurrent(Collections.emptyMap(), propagation, false);
             ctxA.readDownPropagationHeaders(headers);
             ctxA.makeActive();
@@ -122,6 +123,7 @@ public class BrowserPropagationDataStorageTest extends SpringTestBase {
             Map<String, Object> dummyMap = IntStream.rangeClosed(1, 128).boxed()
                     .collect(Collectors.toMap(i -> "key"+i, i -> "value"+i));
             dataStorage.writeData(dummyMap);
+
             InspectitContextImpl ctx = InspectitContextImpl.createFromCurrent(Collections.emptyMap(), propagation, false);
             ctx.readDownPropagationHeaders(headers);
             ctx.makeActive();
@@ -166,7 +168,7 @@ public class BrowserPropagationDataStorageTest extends SpringTestBase {
             ctxA.makeActive();
 
             InspectitContextImpl ctxB = InspectitContextImpl.createFromCurrent(Collections.emptyMap(), propagation, false);
-            ctxB.readDownPropagationHeaders(headers);
+            ctxB.setData(InternalInspectitContext.REMOTE_SESSION_ID, sessionId);
             ctxB.setData("keyB", "valueB");
             ctxB.makeActive();
             ctxB.close();
@@ -187,7 +189,7 @@ public class BrowserPropagationDataStorageTest extends SpringTestBase {
         void verifyNoDownPropagation() {
             when(propagation.isPropagatedWithBrowser(any())).thenReturn(true);
             when(propagation.isPropagatedDownWithinJVM(any())).thenReturn(false);
-            when(propagation.isPropagatedDownWithinJVM(eq("remote_session_id"))).thenReturn(true);
+            when(propagation.isPropagatedDownWithinJVM(eq(InternalInspectitContext.REMOTE_SESSION_ID))).thenReturn(true);
             BrowserPropagationDataStorage dataStorage = sessionStorage.getOrCreateDataStorage(sessionId);
             Map<String, Object> data = new HashMap<>();
             data.put("keyA", "valueA");

--- a/inspectit-ocelot-documentation/docs/tags/tags-exporters.md
+++ b/inspectit-ocelot-documentation/docs/tags/tags-exporters.md
@@ -17,7 +17,7 @@ One GET-endpoint to expose data to external applications and one PUT-endpoint to
 The server is by default started on the port `9000` and data can then be accessed or written by 
 calling 'http://localhost:9000/inspectit'
 
-#### Production environment
+#### Production Environment
 
 The Tags HTTP exporter does not provide any encryption of data and does not perform any authentication.
 Thus, this server should not be exposed directly to the public in a production environment.
@@ -31,7 +31,7 @@ Additionally, make sure that your firewall is not blocking the HTTP-server addre
 The server performs authorization with checking, whether the request origin is allowed to access the server. 
 Additionally, every request has to provide a session-ID to access their own session data.
 
-#### Session identification
+#### Session Identification
 
 Data tags will always be stored behind a provided session-ID to ensure data correlation with its browser.
 The session-ID will be read from a specific request-header. The _**session-id-header**_-property in the HTTP-exporter allows
@@ -41,7 +41,10 @@ The default-instrumentation of InspectIT will check the specified _session-id-he
 Thus, there is no additional configuration necessary to read session-ID from HTTP-headers.
 
 Behind every session-ID, there is a data storage containing all data tags for this session, as long as they are enabled for browser propagation.
-These data storages can only be created, by sending requests to the target application, which the Ocelot-agent is attached to.
+A data storage will be created, if an HTTP request to the target application contains a session-ID inside the
+_session_id_header_. If a data storage already exists for the specified
+session-ID, no new data storage will be created.
+
 You cannot create new data storages for example by pushing data into the HTTP-server by using the API. 
 If a request to the REST-API contains a session-ID, which does not exist in InspectIT, the API will always return 404.
 
@@ -49,7 +52,16 @@ The HTTP-exporter can only store a specific amount of sessions, which can be con
 Sessions will be deleted after their _time-to-live_ is expired. Their time-to-live will be reset everytime a request
 the HTTP-server receives a successful request.
 
-#### Session limits
+#### Non-Remote Session Initialization
+
+It is also possible to create a data storage behind a session-ID inside the inspectIT agent, without
+firstly providing it via an HTTP request to the target application.
+
+For this you can use the data key _remote_session_id_ in the configuration server. You can set the data key via
+the _a_assign_value_ action in the configuration server. After assigning a new value to the _remote_session_id_ data key,
+a new data storage with the specified value as session-ID will be created.
+
+#### Session Limits
 
 There are some limitations for every session to prevent excessive memory consumption.
 The length of the session-ID is restricted to a minimum of 16 characters and a maximum of 512 characters.
@@ -135,7 +147,7 @@ function putTags() {
 }
 ```
 
-### OpenAPI documentation
+### OpenAPI Documentation
 
 Below you can see the OpenAPI documentation for the REST-API in YAML-format:
 


### PR DESCRIPTION
If a BrowserPropagationDataStorage is not created in the first context, but in a later one, earlier created data, which was down propagated still has to be included into the data storage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectIT/inspectit-ocelot/1621)
<!-- Reviewable:end -->
