### PR TITLE
change docker-compose to docker compose

### DIFF
--- a/inspectit-ocelot-documentation/docs/getting-started/docker-examples.md
+++ b/inspectit-ocelot-documentation/docs/getting-started/docker-examples.md
@@ -24,10 +24,10 @@ If you are using Docker Desktop or running Docker in a virtual machine, ensure t
 
 Either [download](https://github.com/inspectIT/inspectit-ocelot-demo/archive/refs/heads/main.zip) or clone the [inspectIT Ocelot-Demo GitHub repository](https://github.com/inspectIT/inspectit-ocelot-demo).
 
-Change into the `spring-petclinic-docker-demo/` directory and execute the following command to launch the desired demo scenario (replace [SCENARIO_POSTFIX] with the postfix of the scenario you would like to launch):
+Execute the following command to launch the desired demo scenario (replace [SCENARIO_POSTFIX] with the postfix of the scenario you would like to launch):
 
 ```bash
-$ docker-compose -f docker-compose-[SCENARIO_POSTFIX].yml up
+$ docker compose -f docker-compose-[SCENARIO_POSTFIX].yml up
 ```
 
 This will start all the Docker containers required for the corresponding demo scenario, including the PetClinic demo application.

--- a/inspectit-ocelot-documentation/docs/getting-started/docker-examples.md
+++ b/inspectit-ocelot-documentation/docs/getting-started/docker-examples.md
@@ -52,6 +52,8 @@ sudo mount --bind /mnt/c /c
 
 For more information, check out the following blog post: [Setting Up Docker for Windows and WSL to Work Flawlessly](https://nickjanetakis.com/blog/setting-up-docker-for-windows-and-wsl-to-work-flawlessly)
 
+If you have issues with Internet connectivity, check out the following post: [WSL2 - Fix Internet connectivity behind corporate proxy](https://gist.github.com/mandeepsmagh/f1d062fc59e4e6115385c2609b5f0448)
+
 ## Demo Scenarios
 
 > In all scenarios you can use `admin` as username and `demo` as password for accessing Grafana and the inspectIT Ocelot Configuration Server.


### PR DESCRIPTION
1. Change docker-compose to docker compose due discontinuity of support and native integration available on docker
2. Add helper for users under corporate VPN for internet connectivity

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectIT/inspectit-ocelot/1637)
<!-- Reviewable:end -->
