### PR TITLE
Revert provider property name change

### DIFF
--- a/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/tags/providers/EnvironmentTagsProviderSettings.java
+++ b/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/tags/providers/EnvironmentTagsProviderSettings.java
@@ -18,8 +18,8 @@ public class EnvironmentTagsProviderSettings {
     private boolean resolveHostName;
 
     /**
-     * If true tries to resolve the host ip using {@link java.net.InetAddress}.
+     * If true tries to resolve the host address using {@link java.net.InetAddress}.
      */
-    private boolean resolveHostIp;
+    private boolean resolveHostAddress;
 
 }

--- a/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/basics.yml
+++ b/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/basics.yml
@@ -13,8 +13,8 @@ inspectit:
         enabled: true
         # should the host name be resolved using InetAddress.getLocalHost(), if false 'host.name' tag is not added by env provider
         resolve-host-name: true
-        # should the host ip be resolved using InetAddress.getLocalHost(), if false 'host.ip' tag is not added by env provider
-        resolve-host-ip: true
+        # should the host address be resolved using InetAddress.getLocalHost(), if false 'host.ip' tag is not added by env provider
+        resolve-host-address: true
     # specifies user defined tag keys and values as a map
     # these tag values would overwrite any value added by the providers, thus you can easily overwrite tags values by your own
     extra: { }
@@ -80,11 +80,17 @@ inspectit:
     #  - no views and measures are created
     enabled: true
 
+    # protection mechanism to prevent writing high cardinality tags
     tag-guard:
+      # true, if the tag-guard should be enabled
       enabled: true
+      # global value for the maximum amount of tag values, can be overwritten for specific measures
       max-values-per-tag: 1000
+      # the interval for checking the current amount of tag values
       schedule-delay: 30s
+      # the file to store the recorded tag values
       database-file: ${inspectit.env.agent-dir}/${inspectit.service-name}/tag-guard-database.json
+      # the replacement value for tags exceeding their specific limit
       overflow-replacement: "TAG_LIMIT_EXCEEDED"
 
   # logging settings

--- a/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/core.yml
+++ b/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/core.yml
@@ -47,5 +47,6 @@ inspectit:
       # used for storing a received remote span id
       remote_parent_span_context:
         down-propagation: JVM_LOCAL
+      # used for storing session ids, which are used for browser-propagation
       remote_session_id:
         down-propagation: JVM_LOCAL

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/tags/impl/EnvironmentTagsProvider.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/tags/impl/EnvironmentTagsProvider.java
@@ -48,7 +48,7 @@ public class EnvironmentTagsProvider implements ICommonTagsProvider {
                 }
             }
 
-            if (conf.isResolveHostIp()) {
+            if (conf.isResolveHostAddress()) {
                 try {
                     envTags.put("host.ip", resolveHostAddress());
                 } catch (UnknownHostException e) {

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/tags/impl/EnvironmentTagsProviderIntTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/tags/impl/EnvironmentTagsProviderIntTest.java
@@ -42,7 +42,7 @@ class EnvironmentTagsProviderIntTest {
     @DirtiesContext
     @TestPropertySource(properties = {
             "inspectit.tags.providers.environment.resolve-host-name=false",
-            "inspectit.tags.providers.environment.resolve-host-ip=false",
+            "inspectit.tags.providers.environment.resolve-host-address=false",
     })
     class Overwritten extends SpringTestBase {
 

--- a/inspectit-ocelot-documentation/docs/breaking-changes/breaking-changes.md
+++ b/inspectit-ocelot-documentation/docs/breaking-changes/breaking-changes.md
@@ -11,14 +11,10 @@ To comply with the [Semantic Conventions](https://opentelemetry.io/docs/concepts
 the environment tags have been renamed.
 
 The tag `host` was renamed to `host.name`. The tag `host_address` has been renamed to `host.ip`.
-Furthermore, the configuration option
-`inspectit.tags.providers.environment.resolve-host-address`
-has been changed to 
-`inspectit.tags.providers.environment.resolve-host-ip`.
 
 In addition, there is a new tag `service.name` which contains the same value as `service`.
 The tag `service` is marked as **deprecated** and will be removed in future versions.
-Please use the tag `service.name` instead.
+Please work with the tag `service.name` instead.
 
 ### Renamed propagation header name
 

--- a/inspectit-ocelot-documentation/docs/metrics/common-tags.md
+++ b/inspectit-ocelot-documentation/docs/metrics/common-tags.md
@@ -50,8 +50,8 @@ The service is resolved from the `inspectit.service-name` property, while the ho
 
 > On machines that have multiple network interfaces the `InetAddress.getLocalHost()` method might not provide desired values for host related tags.
 
-| Property                                                 | Default | Description                                                                                 |
-|----------------------------------------------------------|---------|---------------------------------------------------------------------------------------------|
-| `inspectit.tags.providers.environment.enabled`           | `true`  | Enables or disables the provider.                                                           |
-| `inspectit.tags.providers.environment.resolve-host-name` | `true`  | If `false`, the tag `host.name` containing the resolved host name will not be provided.     |
-| `inspectit.tags.providers.environment.resolve-host-ip`   | `true`  | If `false`, the tag `host.ip` containing the resolved host IP address will not be provided. |
+| Property                                                    | Default | Description                                                                                 |
+|-------------------------------------------------------------|---------|---------------------------------------------------------------------------------------------|
+| `inspectit.tags.providers.environment.enabled`              | `true`  | Enables or disables the provider.                                                           |
+| `inspectit.tags.providers.environment.resolve-host-name`    | `true`  | If `false`, the tag `host.name` containing the resolved host name will not be provided.     |
+| `inspectit.tags.providers.environment.resolve-host-address` | `true`  | If `false`, the tag `host.ip` containing the resolved host IP address will not be provided. |


### PR DESCRIPTION
Let's keep the property `inspectit.tags.providers.environment.resolve-host-address`.
As tag key we will use `host.ip` instead of `host_address`.