### PR TITLE
Remove deprecated service tag

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -25650,5 +25650,5 @@ POM License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LI
 --------------------------------------------------------------------------------
 
 
-This report was generated at Thu Jun 12 14:39:37 UTC 2025.
+This report was generated at Fri Jun 13 14:47:26 UTC 2025.
 

--- a/components/inspectit-ocelot-configschemagenerator/build.gradle
+++ b/components/inspectit-ocelot-configschemagenerator/build.gradle
@@ -1,6 +1,10 @@
+plugins {
+    alias(configServerLibs.plugins.orgSpringframeworkBoot)
+}
+
 dependencies {
     testImplementation(
-            configServerLibs.orgJunitJupiterJunitJupiter
+            configServerLibs.orgSpringframeworkBootSpringBootStarterTest,
     )
 
     implementation(

--- a/gradle/configserverlibs.versions.toml
+++ b/gradle/configserverlibs.versions.toml
@@ -1,8 +1,6 @@
 [versions]
 ioJsonwebtoken = "0.12.6"
 orgEclipseJgit = "7.3.0.202506031305-r"
-# Use same version as spring boot
-orgJunitJupiter = "5.12.2"
 orgSpringframeworkBoot = { strictly = "3.5.0" }
 orgSpringframeworkSecurity = "6.5.0"
 jsonSchemaGenerator = "4.38.0"
@@ -24,7 +22,6 @@ orgEclipseJgitOrgEclipseJgit = { module = "org.eclipse.jgit:org.eclipse.jgit", v
 orgEclipseJgitOrgEclipseJgitSshApache= {module = "org.eclipse.jgit:org.eclipse.jgit.ssh.apache", version.ref = "orgEclipseJgit" }
 orgFlywaydbFlywayCore = "org.flywaydb:flyway-core:11.9.1"
 orgHibernateOrmHibernateCommunityDialects = "org.hibernate.orm:hibernate-community-dialects:6.6.15.Final"
-orgJunitJupiterJunitJupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "orgJunitJupiter" }
 orgSpringdocSpringdocOpenapiStarterWebmvcUi = "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8"
 orgSpringframeworkBootSpringBootStarterActuator = { module = "org.springframework.boot:spring-boot-starter-actuator", version.ref = "orgSpringframeworkBoot" }
 orgSpringframeworkBootSpringBootStarterDataJpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "orgSpringframeworkBoot" }

--- a/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/instrumentation/UserInstrumentationWithMetricsTest.java
+++ b/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/instrumentation/UserInstrumentationWithMetricsTest.java
@@ -59,7 +59,6 @@ public class UserInstrumentationWithMetricsTest extends InstrumentationSysTestBa
         HashMap<String, String> tags = new HashMap<>();
         tags.put("host.name", ".*");
         tags.put("host.ip", ".*");
-        tags.put("service", ".*");
         tags.put("service.name", ".*");
         tags.put("method", "responseTimeMeasuring\\(\\)");
         tags.put("class", UserInstrumentationWithMetricsTest.class.getName());

--- a/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/instrumentation/http/HttpOutMetricTest.java
+++ b/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/instrumentation/http/HttpOutMetricTest.java
@@ -86,7 +86,7 @@ public class HttpOutMetricTest {
         @Test
         void testSuccessStatus() throws Exception {
             InternalInspectitContext ctx = Instances.contextManager.enterNewContext();
-            ctx.setData("service", "apache_client_test");
+            ctx.setData("service.name", "apache_client_test");
             ctx.makeActive();
             client.execute(new HttpGet(WIREMOCK_URL + PATH_200 + "?x=32423"));
             ctx.close();
@@ -94,7 +94,7 @@ public class HttpOutMetricTest {
             TestUtils.waitForOpenCensusQueueToBeProcessed();
 
             Map<String, String> tags = new HashMap<>();
-            tags.put("service", "apache_client_test");
+            tags.put("service.name", "apache_client_test");
             tags.put("http_host", WIREMOCK_HOST_PORT);
             tags.put("http_path", PATH_200);
             tags.put("http_status", "200");
@@ -112,7 +112,7 @@ public class HttpOutMetricTest {
         @Test
         void testErrorStatus() throws Exception {
             InternalInspectitContext ctx = Instances.contextManager.enterNewContext();
-            ctx.setData("service", "apache_client_test");
+            ctx.setData("service.name", "apache_client_test");
             ctx.makeActive();
             client.execute(new HttpGet(WIREMOCK_URL + PATH_500 + "?x=32423"));
             ctx.close();
@@ -120,7 +120,7 @@ public class HttpOutMetricTest {
             TestUtils.waitForOpenCensusQueueToBeProcessed();
 
             Map<String, String> tags = new HashMap<>();
-            tags.put("service", "apache_client_test");
+            tags.put("service.name", "apache_client_test");
             tags.put("http_host", WIREMOCK_HOST_PORT);
             tags.put("http_path", PATH_500);
             tags.put("http_status", "500");
@@ -138,7 +138,7 @@ public class HttpOutMetricTest {
         @Test
         void testExceptionStatus() throws Exception {
             InternalInspectitContext ctx = Instances.contextManager.enterNewContext();
-            ctx.setData("service", "apache_client_test");
+            ctx.setData("service.name", "apache_client_test");
             ctx.makeActive();
             Exception caughtException = null;
             try {
@@ -153,7 +153,7 @@ public class HttpOutMetricTest {
             TestUtils.waitForOpenCensusQueueToBeProcessed();
 
             Map<String, String> tags = new HashMap<>();
-            tags.put("service", "apache_client_test");
+            tags.put("service.name", "apache_client_test");
             tags.put("http_host", "idontexist");
             tags.put("http_path", "");
             tags.put("http_status", caughtException.getClass().getSimpleName());
@@ -180,7 +180,7 @@ public class HttpOutMetricTest {
         @Test
         void testSuccessStatus() throws Exception {
             InternalInspectitContext ctx = Instances.contextManager.enterNewContext();
-            ctx.setData("service", "urlconn_client_test");
+            ctx.setData("service.name", "urlconn_client_test");
             ctx.makeActive();
 
             HttpURLConnection urlConnection = (HttpURLConnection) new URL(WIREMOCK_URL + PATH_200 + "?x=32423").openConnection();
@@ -191,7 +191,7 @@ public class HttpOutMetricTest {
             TestUtils.waitForOpenCensusQueueToBeProcessed();
 
             Map<String, String> tags = new HashMap<>();
-            tags.put("service", "urlconn_client_test");
+            tags.put("service.name", "urlconn_client_test");
             tags.put("http_host", WIREMOCK_HOST_PORT);
             tags.put("http_path", PATH_200);
             tags.put("http_status", "200");
@@ -209,7 +209,7 @@ public class HttpOutMetricTest {
         @Test
         void testErrorStatus() throws Exception {
             InternalInspectitContext ctx = Instances.contextManager.enterNewContext();
-            ctx.setData("service", "urlconn_client_test");
+            ctx.setData("service.name", "urlconn_client_test");
             ctx.makeActive();
 
             HttpURLConnection urlConnection = (HttpURLConnection) new URL(WIREMOCK_URL + PATH_500 + "?x=32423").openConnection();
@@ -220,7 +220,7 @@ public class HttpOutMetricTest {
             TestUtils.waitForOpenCensusQueueToBeProcessed();
 
             Map<String, String> tags = new HashMap<>();
-            tags.put("service", "urlconn_client_test");
+            tags.put("service.name", "urlconn_client_test");
             tags.put("http_host", WIREMOCK_HOST_PORT);
             tags.put("http_path", PATH_500);
             tags.put("http_status", "500");
@@ -238,7 +238,7 @@ public class HttpOutMetricTest {
         @Test
         void testExceptionStatus() {
             InternalInspectitContext ctx = Instances.contextManager.enterNewContext();
-            ctx.setData("service", "urlconn_client_test");
+            ctx.setData("service.name", "urlconn_client_test");
             ctx.makeActive();
 
             Exception caughtException = null;
@@ -255,7 +255,7 @@ public class HttpOutMetricTest {
             TestUtils.waitForOpenCensusQueueToBeProcessed();
 
             Map<String, String> tags = new HashMap<>();
-            tags.put("service", "urlconn_client_test");
+            tags.put("service.name", "urlconn_client_test");
             tags.put("http_host", "idontexist");
             tags.put("http_path", "");
             tags.put("http_status", caughtException.getClass().getSimpleName());

--- a/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/instrumentation/servicegraph/HttpServiceOutMetricTest.java
+++ b/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/instrumentation/servicegraph/HttpServiceOutMetricTest.java
@@ -79,7 +79,7 @@ public class HttpServiceOutMetricTest {
                     Class.forName("org.apache.http.impl.client.InternalHttpClient")), true, 30, TimeUnit.SECONDS);
 
             InternalInspectitContext serviceOverride = Instances.contextManager.enterNewContext();
-            serviceOverride.setData("service", "apache_sg_test");
+            serviceOverride.setData("service.name", "apache_sg_test");
             serviceOverride.makeActive();
             client.execute(URIUtils.extractHost(URI.create(TEST_URL)), new HttpGet(TEST_URL));
             client.close();
@@ -89,7 +89,7 @@ public class HttpServiceOutMetricTest {
 
             Map<String, String> tags = new HashMap<>();
             tags.put("protocol", "http");
-            tags.put("service", "apache_sg_test");
+            tags.put("service.name", "apache_sg_test");
             tags.put("target_service", SERVICE_NAME);
 
             long cnt = ((AggregationData.CountData) TestUtils.getDataForView("service/out/count", tags)).getCount();
@@ -111,7 +111,7 @@ public class HttpServiceOutMetricTest {
             TestUtils.waitForClassInstrumentation(Class.forName("sun.net.www.protocol.http.HttpURLConnection"), true, 30, TimeUnit.SECONDS);
 
             InternalInspectitContext serviceOverride = Instances.contextManager.enterNewContext();
-            serviceOverride.setData("service", "httpurlconn_sg_test");
+            serviceOverride.setData("service.name", "httpurlconn_sg_test");
             serviceOverride.makeActive();
             HttpURLConnection urlConnection = (HttpURLConnection) new URL(TEST_URL).openConnection();
             urlConnection.getResponseCode();
@@ -121,7 +121,7 @@ public class HttpServiceOutMetricTest {
 
             Map<String, String> tags = new HashMap<>();
             tags.put("protocol", "http");
-            tags.put("service", "httpurlconn_sg_test");
+            tags.put("service.name", "httpurlconn_sg_test");
             tags.put("target_service", SERVICE_NAME);
 
             long cnt = ((AggregationData.CountData) TestUtils.getDataForView("service/out/count", tags)).getCount();

--- a/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/instrumentation/servicegraph/JdbcServiceOutMetricTest.java
+++ b/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/instrumentation/servicegraph/JdbcServiceOutMetricTest.java
@@ -59,7 +59,7 @@ public class JdbcServiceOutMetricTest {
         TestUtils.waitForClassInstrumentations(Arrays.asList(JdbcPreparedStatement.class), true, 30, TimeUnit.SECONDS);
 
         InternalInspectitContext ctx = Instances.contextManager.enterNewContext();
-        ctx.setData("service", service);
+        ctx.setData("service.name", service);
         ctx.makeActive();
 
         preparedSelect.execute();
@@ -68,7 +68,7 @@ public class JdbcServiceOutMetricTest {
 
         Map<String, String> tags = new HashMap<>();
         tags.put("protocol", "jdbc");
-        tags.put("service", service);
+        tags.put("service.name", service);
         tags.put("target_external", DB_URL_WITHOUT_JDBC);
 
         long cnt = ((AggregationData.CountData) TestUtils.getDataForView("service/out/count", tags)).getCount();
@@ -87,7 +87,7 @@ public class JdbcServiceOutMetricTest {
         TestUtils.waitForClassInstrumentations(Arrays.asList(JdbcPreparedStatement.class), true, 30, TimeUnit.SECONDS);
 
         InternalInspectitContext ctx = Instances.contextManager.enterNewContext();
-        ctx.setData("service", service);
+        ctx.setData("service.name", service);
         ctx.makeActive();
 
         conn.createStatement().execute(SELECT_SQL);
@@ -96,7 +96,7 @@ public class JdbcServiceOutMetricTest {
 
         Map<String, String> tags = new HashMap<>();
         tags.put("protocol", "jdbc");
-        tags.put("service", service);
+        tags.put("service.name", service);
         tags.put("target_external", DB_URL_WITHOUT_JDBC);
 
         long cnt = ((AggregationData.CountData) TestUtils.getDataForView("service/out/count", tags)).getCount();

--- a/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/instrumentation/servicegraph/ServiceInMetricTest.java
+++ b/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/instrumentation/servicegraph/ServiceInMetricTest.java
@@ -43,7 +43,7 @@ public class ServiceInMetricTest {
 
         try {
             InternalInspectitContext context = Instances.contextManager.enterNewContext();
-            context.setData("service", originService);
+            context.setData("service.name", originService);
             context.makeActive();
 
             HttpURLConnection urlConnection = (HttpURLConnection) new URL(TEST_URL).openConnection();
@@ -82,7 +82,7 @@ public class ServiceInMetricTest {
 
             Map<String, String> tags = new HashMap<>();
             tags.put("protocol", "http");
-            tags.put("service", SERVICE_NAME);
+            tags.put("service.name", SERVICE_NAME);
             tags.put("origin_service", "servlet_origin");
 
             await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {

--- a/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/instrumentation/tracing/TraceSettingsTest.java
+++ b/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/instrumentation/tracing/TraceSettingsTest.java
@@ -29,13 +29,12 @@ public class TraceSettingsTest extends TraceTestBase {
 
         assertTraceExported((spans) -> assertThat(spans).hasSize(1).anySatisfy((sp) -> {
                     assertThat(sp.getName()).endsWith("TraceSettingsTest.attributesSetter");
-                    assertThat(sp.getAttributes().asMap()).hasSize(8)
+                    assertThat(sp.getAttributes().asMap()).hasSize(7)
                             .containsEntry(AttributeKey.stringKey("entry"), "const")
                             .containsEntry(AttributeKey.stringKey("exit"), "Hello A!")
                             .containsEntry(AttributeKey.stringKey("toObfuscate"), "***")
                             .containsEntry(AttributeKey.stringKey("anything"), "***")
                             // plus include all common tags (service + key validation only)
-                            .containsEntry(AttributeKey.stringKey("service"), "systemtest")
                             .containsEntry(AttributeKey.stringKey("service.name"), "systemtest")
                             .containsKeys(AttributeKey.stringKey("host.name"), AttributeKey.stringKey("host.ip"));
                 })
@@ -57,8 +56,8 @@ public class TraceSettingsTest extends TraceTestBase {
 
         assertTraceExported((spans) -> assertThat(spans).hasSize(1).anySatisfy((sp) -> {
                     assertThat(sp.getName()).endsWith("TraceSettingsTest.attributesSetterWithConditions");
-                    assertThat(sp.getAttributes().asMap()).hasSize(4)
-                            .containsKeys(AttributeKey.stringKey("service"),  AttributeKey.stringKey("service.name"),
+                    assertThat(sp.getAttributes().asMap()).hasSize(3)
+                            .containsKeys(AttributeKey.stringKey("service.name"),
                                     AttributeKey.stringKey("host.name"), AttributeKey.stringKey("host.ip"));
                 })
 
@@ -66,10 +65,10 @@ public class TraceSettingsTest extends TraceTestBase {
 
         assertTraceExported((spans) -> assertThat(spans).hasSize(1).anySatisfy((sp) -> {
                     assertThat(sp.getName()).endsWith("TraceSettingsTest.attributesSetterWithConditions");
-                    assertThat(sp.getAttributes().asMap()).hasSize(6)
+                    assertThat(sp.getAttributes().asMap()).hasSize(5)
                             .containsEntry(AttributeKey.stringKey("entry"), "const")
                             .containsEntry(AttributeKey.stringKey("exit"), "Hello B!")
-                            .containsKeys(AttributeKey.stringKey("service"), AttributeKey.stringKey("service.name"),
+                            .containsKeys(AttributeKey.stringKey("service.name"),
                                     AttributeKey.stringKey("host.name"), AttributeKey.stringKey("host.ip"));
                 })
         );
@@ -136,7 +135,7 @@ public class TraceSettingsTest extends TraceTestBase {
 
         assertTraceExported((spans) -> assertThat(spans).hasSize(2).anySatisfy((sp) -> {
                     assertThat(SpanId.isValid(sp.getParentSpanId())).isFalse();
-                    assertThat(sp.getAttributes().asMap()).hasSize(4);
+                    assertThat(sp.getAttributes().asMap()).hasSize(3);
                 }).anySatisfy((sp) -> {
                     assertThat(SpanId.isValid(sp.getParentSpanId())).isTrue();
                     assertThat(sp.getAttributes().asMap()).hasSize(0);
@@ -186,16 +185,16 @@ public class TraceSettingsTest extends TraceTestBase {
             }
 
             //ensure that all method invocations have been combined to single spans
-            assertThat(firstSpan.getAttributes().asMap()).hasSize(6)
+            assertThat(firstSpan.getAttributes().asMap()).hasSize(5)
                     .containsEntry(AttributeKey.stringKey("1"), "a1")
                     .containsEntry(AttributeKey.stringKey("2"), "a2")
-                    .containsKeys(AttributeKey.stringKey("service"), AttributeKey.stringKey("service.name"),
+                    .containsKeys(AttributeKey.stringKey("service.name"),
                             AttributeKey.stringKey("host.name"), AttributeKey.stringKey("host.ip"));
-            assertThat(secondSpan.getAttributes().asMap()).hasSize(7)
+            assertThat(secondSpan.getAttributes().asMap()).hasSize(6)
                     .containsEntry(AttributeKey.stringKey("1"), "b1")
                     .containsEntry(AttributeKey.stringKey("2"), "b2")
                     .containsEntry(AttributeKey.stringKey("3"), "b3")
-                    .containsKeys(AttributeKey.stringKey("service"), AttributeKey.stringKey("service.name"),
+                    .containsKeys(AttributeKey.stringKey("service.name"),
                             AttributeKey.stringKey("host.name"), AttributeKey.stringKey("host.ip"));
 
             //ensure that the timings are valid

--- a/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/utils/TestUtils.java
+++ b/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/utils/TestUtils.java
@@ -247,7 +247,7 @@ public class TestUtils {
         assertThat(orderedTagKeys).contains(tags.keySet().toArray(new String[]{}));
         List<String> expectedTagValues = orderedTagKeys.stream().map(tags::get).collect(Collectors.toList());
 
-        return view.getAggregationMap().entrySet().stream().filter(e -> {
+         List<Map.Entry<List<TagValue>, AggregationData>> entryList = view.getAggregationMap().entrySet().stream().filter(e -> {
             List<TagValue> tagValues = e.getKey();
             for (int i = 0; i < tagValues.size(); i++) {
                 String regex = expectedTagValues.get(i);
@@ -257,7 +257,8 @@ public class TestUtils {
                 }
             }
             return true;
-        }).map(Map.Entry::getValue).findFirst().orElse(null);
+        }).collect(Collectors.toList());
+         return entryList.stream().map(Map.Entry::getValue).findFirst().orElse(null);
     }
 
     public static TimeSeries getTimeseries(String metricName, Map<String, String> tags) {

--- a/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/actions/_shared/debug.yml
+++ b/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/actions/_shared/debug.yml
@@ -26,4 +26,4 @@ inspectit:
           'b': 'Object'
         is-void: true
         value-body: |
-          System.out.println(a + "" + b);
+          System.out.println(a + " " + b);

--- a/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/rules/_shared/service-graph.yml
+++ b/inspectit-ocelot-config/src/main/resources/rocks/inspectit/ocelot/config/default/instrumentation/rules/_shared/service-graph.yml
@@ -89,12 +89,12 @@ inspectit:
           'servicegraph_target_service':
             action: 'a_assign_value'
             data-input: 
-              'value': 'service'
+              'value': 'service.name'
         exit:
           'servicegraph_target_service':
             action: 'a_assign_value'
             data-input: 
-              'value': 'service'
+              'value': 'service.name'
 
       'r_servicegraph_prepare_down_propagation':
         docs:
@@ -107,7 +107,7 @@ inspectit:
           'servicegraph_origin_service':
             action: 'a_assign_value'
             data-input: 
-              'value': 'service'
+              'value': 'service.name'
 
       'r_servicegraph_inbound_record_method':
         docs:
@@ -205,4 +205,3 @@ inspectit:
             only-if-true: 'servicegraph_is_entry'
             data-input: 
               'value': 'method_duration'
-        

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/tags/impl/EnvironmentTagsProvider.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/tags/impl/EnvironmentTagsProvider.java
@@ -31,11 +31,6 @@ public class EnvironmentTagsProvider implements ICommonTagsProvider {
         if (conf.isEnabled()) {
             Map<String, String> envTags = new HashMap<>();
 
-            // DEPRECATED: To comply with OTel semantic conventions, we should replace the 'service' tag
-            // with 'service.name'
-            envTags.put("service", configuration.getServiceName());
-
-            // We should use only this one in the future
             envTags.put(ServiceAttributes.SERVICE_NAME.getKey(), configuration.getServiceName());
 
             if (conf.isResolveHostName()) {

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/tags/impl/EnvironmentTagsProviderIntTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/tags/impl/EnvironmentTagsProviderIntTest.java
@@ -30,8 +30,7 @@ class EnvironmentTagsProviderIntTest {
         @Test
         public void happyPath() {
             assertThat(provider.getTags(env.getCurrentConfig()))
-                    .hasSize(4)
-                    .containsEntry("service", SERVICE_NAME)
+                    .hasSize(3)
                     .containsEntry("service.name", SERVICE_NAME)
                     .containsKey("host.name")
                     .containsKey("host.ip");
@@ -55,7 +54,7 @@ class EnvironmentTagsProviderIntTest {
         @Test
         public void happyPath() {
             assertThat(provider.getTags(env.getCurrentConfig()))
-                    .hasSize(2)
+                    .hasSize(1)
                     .containsKeys("service.name");
         }
     }
@@ -96,7 +95,7 @@ class EnvironmentTagsProviderIntTest {
         public void enable() {
             updateProperties(properties -> properties.withProperty("inspectit.tags.providers.environment.enabled", Boolean.TRUE));
 
-            assertThat(provider.getTags(env.getCurrentConfig())).hasSize(4);
+            assertThat(provider.getTags(env.getCurrentConfig())).hasSize(3);
         }
     }
 
@@ -117,7 +116,7 @@ class EnvironmentTagsProviderIntTest {
                             .withProperty("inspectit.service-name", "updatedName")
             );
 
-            assertThat(provider.getTags(env.getCurrentConfig())).hasSize(4)
+            assertThat(provider.getTags(env.getCurrentConfig())).hasSize(3)
                     .containsEntry("service.name", "updatedName");
         }
     }

--- a/inspectit-ocelot-documentation/docs/breaking-changes/breaking-changes.md
+++ b/inspectit-ocelot-documentation/docs/breaking-changes/breaking-changes.md
@@ -3,6 +3,12 @@ id: Breaking Changes
 title: Breaking Changes
 ---
 
+## Breaking changes in 2.6.12
+
+### Removed deprecated service tag
+
+The tag `service` was fully removed from metrics. Please work with the tag `service.name` instead.
+
 ## Breaking changes in 2.6.11
 
 ### Renamed environment tag keys

--- a/inspectit-ocelot-documentation/docs/breaking-changes/breaking-changes.md
+++ b/inspectit-ocelot-documentation/docs/breaking-changes/breaking-changes.md
@@ -7,7 +7,7 @@ title: Breaking Changes
 
 ### Removed deprecated service tag
 
-The tag `service` was fully removed from metrics. Please work with the tag `service.name` instead.
+The tag `service` was fully removed. Please work with the tag `service.name` instead.
 
 ## Breaking changes in 2.6.11
 

--- a/inspectit-ocelot-documentation/docs/instrumentation/data-propagation.md
+++ b/inspectit-ocelot-documentation/docs/instrumentation/data-propagation.md
@@ -86,7 +86,7 @@ In fact, we designed the inspectIT context so that it acts as a superset of the 
 Firstly, when an instrumented method is entered, a new inspectIT context is created. 
 At this point, it imports any tag values published by OpenCensus directly as data. 
 This also includes the [common tags](metrics/common-tags.md) created by inspectIT. This means, that you can simply read (and override) 
-values for common tags such as `service` or `host_address` at any rule.
+values for common tags such as `service.name` or `host.name` at any rule.
 
 The integration is even deeper if you configured the agent to also extract the metrics from manual instrumentation 
 in your application via OpenCensus.

--- a/inspectit-ocelot-documentation/docs/metrics/common-tags.md
+++ b/inspectit-ocelot-documentation/docs/metrics/common-tags.md
@@ -17,10 +17,10 @@ Each provider specifies a priority and if the same tag keys are supplied by two 
 
 inspectIT Ocelot currently supports the following tag providers:
 
-| Provider                                | Tags provided                                                  | Supports run-time updates | Enabled by default | Priority |
-|-----------------------------------------|----------------------------------------------------------------|---------------------------|--------------------|----------|
-| [User Defined Tags](#user-defined-tags) | -                                                              | Yes                       | No                 | HIGH     |
-| [Environment Tags](#environment-tags)   | `service.name`, `host.name`, `host.ip`, `service` (deprecated) | Yes                       | Yes                | LOW      |
+| Provider                                | Tags provided                          | Supports run-time updates | Enabled by default | Priority |
+|-----------------------------------------|----------------------------------------|---------------------------|--------------------|----------|
+| [User Defined Tags](#user-defined-tags) | -                                      | Yes                       | No                 | HIGH     |
+| [Environment Tags](#environment-tags)   | `service.name`, `host.name`, `host.ip` | Yes                       | Yes                | LOW      |
 
 > Run-time updates currently only support changing of a tag value, but not adding or removing tags.
 


### PR DESCRIPTION
As announced in the previous release, the `service` tag will be replaced by the `service.name` tag in metrics