### PR TITLE
Update GitHub notifications

### DIFF
--- a/.github/workflows/agent_security_check.yml
+++ b/.github/workflows/agent_security_check.yml
@@ -44,7 +44,7 @@ jobs:
               "from": "inspectIT Ocelot DepCheck <inspectit-ocelot-depcheck@resend.dev>",
               "to": ["info.inspectit@novatec-gmbh.de"],
               "subject": "Ocelot-Agent Dependency-Check Report - ${{ steps.depcheck.outcome }}",
-              "html": "<p>The Dependency-Check for inspectit-ocelot-agent completed with status: <strong>${{ steps.depcheck.outcome }}</strong>.</p><p>Please check the report here: <a href='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'></a></p>"
+              "html": "<p>The Dependency-Check for inspectit-ocelot-agent completed with status: <strong>${{ steps.depcheck.outcome }}</strong></p><p>Please check the report here: <a href='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'>View Report</a></p>"
             }'
       # if DependencyCheck failed, the job should also fail, but only after the results were uploaded
       - name: Validate DependencyCheck outcome

--- a/.github/workflows/agent_security_check.yml
+++ b/.github/workflows/agent_security_check.yml
@@ -34,13 +34,18 @@ jobs:
         with:
           name: dependency-check-report-ocelot-agent
           path: ${{ github.workspace }}/reports
-      - name: Send Notification
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            text: "*Ocelot-Agent Dependency-Check Report*: ${{ steps.depcheck.outcome }}\nPlease check the report here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      # Since GitHub cannot send emails directly, we use an external API
+      - name: Send Notification via Resend
+        run: |
+          curl -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer ${{ secrets.RESEND_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "from": "inspectIT Ocelot DepCheck <inspectit-ocelot-depcheck@github.com>",
+              "to": ["info.inspectit@novatec-gmbh.de"],
+              "subject": "Ocelot-Agent Dependency-Check Report - ${{ steps.depcheck.outcome }}",
+              "text": "The Dependency-Check for inspectit-ocelot-agent completed with status: ${{ steps.depcheck.outcome }}.\n\nPlease check the report here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }'
       # if DependencyCheck failed, the job should also fail, but only after the results were uploaded
       - name: Validate DependencyCheck outcome
         if: ${{ steps.depcheck.outcome == 'failure' }}

--- a/.github/workflows/agent_security_check.yml
+++ b/.github/workflows/agent_security_check.yml
@@ -41,10 +41,10 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.RESEND_API_KEY }}" \
             -H "Content-Type: application/json" \
             -d '{
-              "from": "inspectIT Ocelot DepCheck <inspectit-ocelot-depcheck@github.com>",
+              "from": "inspectIT Ocelot DepCheck <inspectit-ocelot-depcheck@resend.dev>",
               "to": ["info.inspectit@novatec-gmbh.de"],
               "subject": "Ocelot-Agent Dependency-Check Report - ${{ steps.depcheck.outcome }}",
-              "text": "The Dependency-Check for inspectit-ocelot-agent completed with status: ${{ steps.depcheck.outcome }}.\n\nPlease check the report here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "html": "<p>The Dependency-Check for inspectit-ocelot-agent completed with status: <strong>${{ steps.depcheck.outcome }}</strong>.</p><p>Please check the report here: <a href='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'></a></p>"
             }'
       # if DependencyCheck failed, the job should also fail, but only after the results were uploaded
       - name: Validate DependencyCheck outcome

--- a/.github/workflows/configurationserver_security_check.yml
+++ b/.github/workflows/configurationserver_security_check.yml
@@ -96,7 +96,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.RESEND_API_KEY }}" \
             -H "Content-Type: application/json" \
             -d '{
-              "from": "inspectIT Ocelot DepCheck <inspectit-ocelot-depcheck@resend.dev",
+              "from": "inspectIT Ocelot DepCheck <inspectit-ocelot-depcheck@resend.dev>",
               "to": ["info.inspectit@novatec-gmbh.de"],
               "subject": "Ocelot-Configuration-Server Dependency-Check Report - ${{ steps.depcheck.outcome }}",
               "html": "<p>The Dependency-Check for inspectit-ocelot-configurationserver completed with status: <strong>${{ steps.depcheck.outcome }}</strong></p><p>Please check the report here: <a href='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'>View Report</a></p>"

--- a/.github/workflows/configurationserver_security_check.yml
+++ b/.github/workflows/configurationserver_security_check.yml
@@ -99,7 +99,7 @@ jobs:
               "from": "inspectIT Ocelot DepCheck <inspectit-ocelot-depcheck@resend.dev",
               "to": ["info.inspectit@novatec-gmbh.de"],
               "subject": "Ocelot-Configuration-Server Dependency-Check Report - ${{ steps.depcheck.outcome }}",
-              "html": "<p>The Dependency-Check for inspectit-ocelot-configurationserver completed with status: <strong>${{ steps.depcheck.outcome }}</strong>.</p><p>Please check the report here: <a href='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'></a></p>"
+              "html": "<p>The Dependency-Check for inspectit-ocelot-configurationserver completed with status: <strong>${{ steps.depcheck.outcome }}</strong></p><p>Please check the report here: <a href='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'>View Report</a></p>"
             }'
       # if DependencyCheck failed, the job should also fail, but only after the results were uploaded
       - name: Validate DependencyCheck outcome

--- a/.github/workflows/configurationserver_security_check.yml
+++ b/.github/workflows/configurationserver_security_check.yml
@@ -96,10 +96,10 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.RESEND_API_KEY }}" \
             -H "Content-Type: application/json" \
             -d '{
-              "from": "inspectIT Ocelot DepCheck <inspectit-ocelot-depcheck@github.com>",
+              "from": "inspectIT Ocelot DepCheck <inspectit-ocelot-depcheck@resend.dev",
               "to": ["info.inspectit@novatec-gmbh.de"],
               "subject": "Ocelot-Configuration-Server Dependency-Check Report - ${{ steps.depcheck.outcome }}",
-              "text": "The Dependency-Check for inspectit-ocelot-configurationserver completed with status: ${{ steps.depcheck.outcome }}.\n\nPlease check the report here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "html": "<p>The Dependency-Check for inspectit-ocelot-configurationserver completed with status: <strong>${{ steps.depcheck.outcome }}</strong>.</p><p>Please check the report here: <a href='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'></a></p>"
             }'
       # if DependencyCheck failed, the job should also fail, but only after the results were uploaded
       - name: Validate DependencyCheck outcome

--- a/.github/workflows/configurationserver_security_check.yml
+++ b/.github/workflows/configurationserver_security_check.yml
@@ -89,13 +89,18 @@ jobs:
           else
             echo "DEP_CHECK_STATUS=success" >> $GITHUB_ENV
           fi
-      - name: Send Notification
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            text: "*Ocelot-Configuration-Server Dependency-Check Report*: ${{ env.DEP_CHECK_STATUS }}\nPlease check the report here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      # Since GitHub cannot send emails directly, we use an external API
+      - name: Send Notification via Resend
+        run: |
+          curl -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer ${{ secrets.RESEND_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "from": "inspectIT Ocelot DepCheck <inspectit-ocelot-depcheck@github.com>",
+              "to": ["info.inspectit@novatec-gmbh.de"],
+              "subject": "Ocelot-Configuration-Server Dependency-Check Report - ${{ steps.depcheck.outcome }}",
+              "text": "The Dependency-Check for inspectit-ocelot-configurationserver completed with status: ${{ steps.depcheck.outcome }}.\n\nPlease check the report here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }'
       # if DependencyCheck failed, the job should also fail, but only after the results were uploaded
       - name: Validate DependencyCheck outcome
         if: ${{ env.DEP_CHECK_STATUS == 'failure' }}


### PR DESCRIPTION
Replace Slack notifications with Email. Since GitHub cannot send emails directy, we use [Resend](https://resend.com).