### PR TITLE
Enable virtual threads for configuration server

### DIFF
--- a/components/inspectit-ocelot-configurationserver/src/main/resources/application.yml
+++ b/components/inspectit-ocelot-configurationserver/src/main/resources/application.yml
@@ -20,6 +20,8 @@ spring:
     baselineOnMigrate: true
     baselineVersion: 1
 
+  threads.virtual.enabled: true
+
 # server properties - see https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-application-properties.html#server-properties
 server:
   port: 8090


### PR DESCRIPTION
Spring Boot supports virtual threads for Java 21 since version 3.2, which are recommend for server applications that handle a lot of requests. In our case handling a lot of agents requesting their configuration.