### PR TITLE
Closes #576 - Use replace-regex when obfuscating data

### DIFF
--- a/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/instrumentation/tracing/TraceSettingsTest.java
+++ b/inspectit-ocelot-agent/src/system-test/java/rocks/inspectit/ocelot/instrumentation/tracing/TraceSettingsTest.java
@@ -32,15 +32,13 @@ public class TraceSettingsTest extends TraceTestBase {
                     assertThat(sp.getAttributes().asMap()).hasSize(7)
                             .containsEntry(AttributeKey.stringKey("entry"), "const")
                             .containsEntry(AttributeKey.stringKey("exit"), "Hello A!")
-                            .containsEntry(AttributeKey.stringKey("toObfuscate"), "***")
-                            .containsEntry(AttributeKey.stringKey("anything"), "***")
+                            .containsEntry(AttributeKey.stringKey("toObfuscate"), "***") // obfuscate everything for key 'toObfuscate'
+                            .containsEntry(AttributeKey.stringKey("anything"), "to***Value") // obfuscate the term 'Obfuscate' for values 'toObfuscateValue'
                             // plus include all common tags (service + key validation only)
                             .containsEntry(AttributeKey.stringKey("service.name"), "systemtest")
                             .containsKeys(AttributeKey.stringKey("host.name"), AttributeKey.stringKey("host.ip"));
                 })
-
         );
-
     }
 
     String attributesSetterWithConditions(boolean captureAttributes) {
@@ -60,7 +58,6 @@ public class TraceSettingsTest extends TraceTestBase {
                             .containsKeys(AttributeKey.stringKey("service.name"),
                                     AttributeKey.stringKey("host.name"), AttributeKey.stringKey("host.ip"));
                 })
-
         );
 
         assertTraceExported((spans) -> assertThat(spans).hasSize(1).anySatisfy((sp) -> {
@@ -92,7 +89,6 @@ public class TraceSettingsTest extends TraceTestBase {
                     assertThat(sp.getName()).endsWith("TraceSettingsTest.nestedC");
                     assertThat(SpanId.isValid(sp.getParentSpanId())).isFalse();
                 })
-
         );
         assertTraceExported((spans) -> assertThat(spans).hasSize(2).anySatisfy((sp) -> {
                     assertThat(sp.getName()).endsWith("TraceSettingsTest.conditionalRoot");
@@ -378,7 +374,6 @@ public class TraceSettingsTest extends TraceTestBase {
                     .noneSatisfy(sp -> assertThat(sp.getName()).isEqualTo("TraceSettingsTest.nestedSamplingTestNestedDefault"))
                     .noneSatisfy(sp -> assertThat(sp.getName()).isEqualTo("TraceSettingsTest.nestedSamplingTestNested"));
         }
-
     }
 
     void withErrorStatus(Object status) {

--- a/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/privacy/obfuscation/ObfuscationPattern.java
+++ b/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/privacy/obfuscation/ObfuscationPattern.java
@@ -28,8 +28,6 @@ public class ObfuscationPattern {
     private String pattern;
 
     /**
-     * <b>Note: This is reserved for future use and has no impact at the moment.</b>
-     * <p>
      * Regular expression to use when replacing the value to be obfuscated. Matched regex will be replaced with <code>***</code>.
      * If not specified, the whole value to obfuscate will be replaced with <code>***</code>.
      */

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/privacy/obfuscation/ObfuscationManager.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/privacy/obfuscation/ObfuscationManager.java
@@ -74,11 +74,16 @@ public class ObfuscationManager {
                     try {
                         int compileFlag = p.isCaseInsensitive() ? Pattern.CASE_INSENSITIVE : 0;
                         Pattern compiledPattern = Pattern.compile(p.getPattern(), compileFlag);
+
+                        Pattern compiledReplaceRegex = null;
+                        if (p.getReplaceRegex() != null && !p.getReplaceRegex().isEmpty())
+                            compiledReplaceRegex = Pattern.compile(p.getReplaceRegex(), compileFlag);
+
                         PatternObfuscatory.PatternEntry patternEntry = PatternObfuscatory.PatternEntry.builder()
                                 .pattern(compiledPattern)
                                 .checkKey(p.isCheckKey())
                                 .checkData(p.isCheckData())
-                                .replaceRegex(p.getReplaceRegex())
+                                .replaceRegex(compiledReplaceRegex)
                                 .build();
                         return Stream.of(patternEntry);
                     } catch (Exception e) {

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/privacy/obfuscation/ObfuscationManagerTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/privacy/obfuscation/ObfuscationManagerTest.java
@@ -150,7 +150,7 @@ class ObfuscationManagerTest {
             obfuscatory.putSpanAttribute(span, "ABC", "abc");
             obfuscatory.putSpanAttribute(span, "DEF", "123");
 
-            verify(span).setAttribute(AttributeKey.stringKey("abc"), "***");
+            verify(span).setAttribute(AttributeKey.stringKey("abc"), "a***");
             verify(span).setAttribute(AttributeKey.stringKey("ABC"), "abc");
             verify(span).setAttribute(AttributeKey.stringKey("DEF"), "123");
         }
@@ -262,7 +262,6 @@ class ObfuscationManagerTest {
             obfuscatory.putSpanAttribute(span, "double", Double.valueOf(1.338d));
             verify(span).setAttribute(AttributeKey.doubleKey("double"), 1.338d);
             obfuscatory.putSpanAttribute(span, "float", Float.valueOf(1.337f));
-            // TODO: do we want to avoid the 'added' precision by double? Then we need to change it accordingly in the IObfuscatory.
             verify(span).setAttribute(AttributeKey.doubleKey("float"), 1.337d);
             verifyNoMoreInteractions(span);
 
@@ -308,5 +307,4 @@ class ObfuscationManagerTest {
             verifyNoMoreInteractions(span);
         }
     }
-
 }

--- a/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/privacy/obfuscation/impl/PatternObfuscatoryTest.java
+++ b/inspectit-ocelot-core/src/test/java/rocks/inspectit/ocelot/core/privacy/obfuscation/impl/PatternObfuscatoryTest.java
@@ -76,12 +76,14 @@ class PatternObfuscatoryTest {
             PatternObfuscatory.PatternEntry.PatternEntryBuilder entryBuilder = PatternObfuscatory.PatternEntry.builder();
             entryBuilder.pattern(p1);
             entryBuilder.checkKey(true);
-            entryBuilder.replaceRegex("grad");
+            entryBuilder.replaceRegex(Pattern.compile("grad"));
             PatternObfuscatory patternObfuscatory = new PatternObfuscatory(Collections.singleton(entryBuilder.build()));
 
             patternObfuscatory.putSpanAttribute(span, "abc", "belgrade");
+            patternObfuscatory.putSpanAttribute(span, "xyz", "berlin");
 
-            verify(span).setAttribute(AttributeKey.stringKey("abc"), "***");
+            verify(span).setAttribute(AttributeKey.stringKey("abc"), "bel***e");
+            verify(span).setAttribute(AttributeKey.stringKey("xyz"), "berlin");
             verifyNoMoreInteractions(span);
         }
 
@@ -116,12 +118,14 @@ class PatternObfuscatoryTest {
             PatternObfuscatory.PatternEntry.PatternEntryBuilder entryBuilder = PatternObfuscatory.PatternEntry.builder();
             entryBuilder.pattern(p1);
             entryBuilder.checkData(true);
-            entryBuilder.replaceRegex("[ac]");
+            entryBuilder.replaceRegex(Pattern.compile("[ac]")); // a or c
             PatternObfuscatory patternObfuscatory = new PatternObfuscatory(Collections.singleton(entryBuilder.build()));
 
             patternObfuscatory.putSpanAttribute(span, "belgrade", "abc");
+            patternObfuscatory.putSpanAttribute(span, "berlin", "xzy");
 
-            verify(span).setAttribute(AttributeKey.stringKey("belgrade"), "***");
+            verify(span).setAttribute(AttributeKey.stringKey("belgrade"), "***b***");
+            verify(span).setAttribute(AttributeKey.stringKey("berlin"), "xzy");
             verifyNoMoreInteractions(span);
         }
 
@@ -135,7 +139,7 @@ class PatternObfuscatoryTest {
             entryBuilder2.pattern(p2);
             entryBuilder2.checkKey(true);
             entryBuilder2.checkData(true);
-            entryBuilder2.replaceRegex("[47]");
+            entryBuilder2.replaceRegex(Pattern.compile("[47]")); // 4 or 7
 
             PatternObfuscatory patternObfuscatory = new PatternObfuscatory(Arrays.asList(entryBuilder1.build(), entryBuilder2.build()));
 
@@ -151,12 +155,10 @@ class PatternObfuscatoryTest {
             verify(span).setAttribute(AttributeKey.stringKey("efg"), "***");
             verify(span).setAttribute(AttributeKey.stringKey("ABC"), "abc");
             verify(span).setAttribute(AttributeKey.stringKey("ABC"), "ABC");
-            verify(span).setAttribute(AttributeKey.stringKey("012"), "***");
-            verify(span).setAttribute(AttributeKey.stringKey("345"), "***");
-            verify(span).setAttribute(AttributeKey.stringKey("ABC"), "***");
+            verify(span).setAttribute(AttributeKey.stringKey("012"), "abc");
+            verify(span).setAttribute(AttributeKey.stringKey("345"), "6***8");
+            verify(span).setAttribute(AttributeKey.stringKey("ABC"), "23***");
             verifyNoMoreInteractions(span);
         }
-
     }
-
 }

--- a/inspectit-ocelot-documentation/docs/tracing/privacy.md
+++ b/inspectit-ocelot-documentation/docs/tracing/privacy.md
@@ -54,15 +54,15 @@ inspectit:
   privacy:
     obfuscation:
       patterns:
-        - pattern: 'address'
+        - pattern: '.*address.*'  # contains 'address' 
 ```
 The following table shows the effect of the previous obfuscation configuration on collected span attributes:
 
-| Collected Attributes                 | Resulting Attributes         |
-|--------------------------------------|------------------------------|
-| `"companyAddress": "Sunny Road 13B"` | `"companyAddress": "***"`    |
-| `"address": "Milkey Road 17"`        | `"address": "***"`           |
-| `"action": "address update"`         | `"action": "address update"` |
+| Collected Attributes                 | Resulting Attributes          |
+|--------------------------------------|-------------------------------|
+| `"companyAddress": "Sunny Road 13B"` | `"companyAddress": "***"`     |
+| `"address": "Milkey Road 17"`        | `"address": "***"`            |
+| `"action0": "address update"`        | `"action1": "address update"` |
 
 ### Example 2
 
@@ -73,7 +73,7 @@ inspectit:
   privacy:
     obfuscation:
       patterns:
-        - pattern: 'address'
+        - pattern: '.*address.*'    
           case-insensitive: false   # ignore capitalization
           check-key: true           # this is true by default
           check-data: true          # also check the attributes value
@@ -85,7 +85,7 @@ The following table shows the effect of the previous obfuscation configuration o
 |--------------------------------------|--------------------------------------|
 | `"companyAddress": "Sunny Road 13B"` | `"companyAddress": "Sunny Road 13B"` |
 | `"address": "Milkey Road 17"`        | `"address": "***"`                   |
-| `"action": "address update"`         | `"action": "***"`                    |
+| `"action0": "address update"`        | `"action1": "***"`                   |
 
 ### Example 3
 
@@ -96,11 +96,11 @@ inspectit:
   privacy:
     obfuscation:
       patterns:
-        - pattern: 'address'
-          case-insensitive: false  
+        - pattern: '.*address.*'
+          case-insensitive: true  
           check-key: true           
           check-data: true          
-          replace-regex: [0-9]+     # replace any numbers
+          replace-regex: '[0-9]+'   # replace any numbers
 ```
 
 The following table shows the effect of the previous obfuscation configuration on collected span attributes:
@@ -109,4 +109,4 @@ The following table shows the effect of the previous obfuscation configuration o
 |--------------------------------------|---------------------------------------|
 | `"companyAddress": "Sunny Road 13B"` | `"companyAddress": "Sunny Road ***B"` |
 | `"address": "Milkey Road 17"`        | `"address": "Milkey Road ***"`        |
-| `"action1": "address update"`        | `"action1": "address update"`         |
+| `"action0": "address update"`        | `"action1": "address update"`         |

--- a/inspectit-ocelot-documentation/docs/tracing/privacy.md
+++ b/inspectit-ocelot-documentation/docs/tracing/privacy.md
@@ -3,14 +3,14 @@ id: privacy
 title: Data Privacy
 ---
 
-InspectIT Ocelot offers you a mechanism to protect your privacy when collecting traces and to prevent the collection of sensitive data.
-This ensures that no sensitive data will leave your application.
+InspectIT Ocelot offers you a mechanism to protect your privacy when collecting traces and to prevent the collection of 
+sensitive data. This ensures that no sensitive data will leave your application.
 
 ## Data Obfuscation
 
 The Ocelot agent configuration allows specification of the data obfuscation rules which will be applied when:
 
-1. collecting span attributes
+1. Collecting span attributes
 
 This way you can globally protect against collecting and storing user sensitive information.
 This can help to implement requirements regarding the strict GDPR rules.
@@ -33,12 +33,13 @@ Note that obfuscation is enabled by default. However, setting `inspectit.privacy
 
 Each pattern entry can be customized by following properties: 
 
-|Property |Default| Description
-|---|---|---|
-|`pattern`|-| The regular expression used to match data for obfuscation.
-|`case-insensitive`|`true`| Denoting whether this pattern should be complied as case insensitive.
-|`check-key`|`true`| Denoting whether this pattern should be tested against the key of the collected attribute.
-|`check-data`|`false`| Denoting whether this pattern should be tested against the actual value of the collected data.
+| Property           | Default | Description                                                                                    |
+|--------------------|---------|------------------------------------------------------------------------------------------------|
+| `pattern`          | -       | The regular expression used to match data for obfuscation.                                     |
+| `case-insensitive` | `true`  | Denoting whether this pattern should be complied as case insensitive.                          |
+| `check-key`        | `true`  | Denoting whether this pattern should be tested against the key of the collected attribute.     |
+| `check-data`       | `false` | Denoting whether this pattern should be tested against the actual value of the collected data. |
+| `replace-regex`    | -       | The regular expression used to obfuscate specific parts of the data value                      |
 
 ## Examples
 
@@ -57,11 +58,11 @@ inspectit:
 ```
 The following table shows the effect of the previous obfuscation configuration on collected span attributes:
 
-|Collected Attributes|Resulting Attributes
-|---|---|
-|`"companyAddress": "Sunny Road 13B"`|`"companyAddress": "***"`
-|`"address": "Milkey Road 17"`|`"address": "***"`
-|`"action": "address update"`|`"action": "address update"`
+| Collected Attributes                 | Resulting Attributes         |
+|--------------------------------------|------------------------------|
+| `"companyAddress": "Sunny Road 13B"` | `"companyAddress": "***"`    |
+| `"address": "Milkey Road 17"`        | `"address": "***"`           |
+| `"action": "address update"`         | `"action": "address update"` |
 
 ### Example 2
 
@@ -80,12 +81,32 @@ inspectit:
 
 The following table shows the effect of the previous obfuscation configuration on collected span attributes:
 
-|Collected Attributes|Resulting Attributes
-|---|---|
-|`"companyAddress": "Sunny Road 13B"`|`"companyAddress": "Sunny Road 13B"`
-|`"address": "Milkey Road 17"`|`"address": "***"`
-|`"action": "address update"`|`"action": "***"`
+| Collected Attributes                 | Resulting Attributes                 |
+|--------------------------------------|--------------------------------------|
+| `"companyAddress": "Sunny Road 13B"` | `"companyAddress": "Sunny Road 13B"` |
+| `"address": "Milkey Road 17"`        | `"address": "***"`                   |
+| `"action": "address update"`         | `"action": "***"`                    |
 
-:::note Obfuscation Value and Pattern
-For now, all obfuscated values are replaced with three stars `***`. This could be changed in future Ocelot releases in favor of a replace regex.
-:::
+### Example 3
+
+This configuration masks all attribute values where the corresponding attribute key or the value itself contain `address`. In this example, the pattern is case-sensitive.
+
+```yaml
+inspectit:
+  privacy:
+    obfuscation:
+      patterns:
+        - pattern: 'address'
+          case-insensitive: false  
+          check-key: true           
+          check-data: true          
+          replace-regex: [0-9]+     # replace any numbers
+```
+
+The following table shows the effect of the previous obfuscation configuration on collected span attributes:
+
+| Collected Attributes                 | Resulting Attributes                  |
+|--------------------------------------|---------------------------------------|
+| `"companyAddress": "Sunny Road 13B"` | `"companyAddress": "Sunny Road ***B"` |
+| `"address": "Milkey Road 17"`        | `"address": "Milkey Road ***"`        |
+| `"action1": "address update"`        | `"action1": "address update"`         |


### PR DESCRIPTION
Closes #576

Replace-Regex patterns will be compiled for every configuration change. During attribute writing the patterns should be ready to use.