### PR TITLE
Try out wrapper for functional interfaces

### DIFF
--- a/inspectit-ocelot-bootstrap/src/main/java/rocks/inspectit/ocelot/bootstrap/Instances.java
+++ b/inspectit-ocelot-bootstrap/src/main/java/rocks/inspectit/ocelot/bootstrap/Instances.java
@@ -6,10 +6,7 @@ import rocks.inspectit.ocelot.bootstrap.correlation.LogTraceCorrelator;
 import rocks.inspectit.ocelot.bootstrap.correlation.TraceIdInjector;
 import rocks.inspectit.ocelot.bootstrap.correlation.noop.NoopLogTraceCorrelator;
 import rocks.inspectit.ocelot.bootstrap.correlation.noop.NoopTraceIdInjector;
-import rocks.inspectit.ocelot.bootstrap.exposed.InspectitAgentInfo;
-import rocks.inspectit.ocelot.bootstrap.exposed.ObjectAttachments;
-import rocks.inspectit.ocelot.bootstrap.exposed.InspectitReflection;
-import rocks.inspectit.ocelot.bootstrap.exposed.InspectitRegex;
+import rocks.inspectit.ocelot.bootstrap.exposed.*;
 import rocks.inspectit.ocelot.bootstrap.instrumentation.IHookManager;
 import rocks.inspectit.ocelot.bootstrap.instrumentation.noop.*;
 import rocks.inspectit.ocelot.bootstrap.opentelemetry.IOpenTelemetryController;
@@ -51,6 +48,8 @@ public class Instances {
     public static LogTraceCorrelator logTraceCorrelator = NoopLogTraceCorrelator.INSTANCE;
 
     public static TraceIdInjector traceIdInjector = NoopTraceIdInjector.INSTANCE;
+
+    public static InspectitWrapper wrapper = NoopInspectitWrapper.INSTANCE;
 
     public static IOpenTelemetryController openTelemetryController = NoopOpenTelemetryController.INSTANCE;
 }

--- a/inspectit-ocelot-bootstrap/src/main/java/rocks/inspectit/ocelot/bootstrap/exposed/InspectitWrapper.java
+++ b/inspectit-ocelot-bootstrap/src/main/java/rocks/inspectit/ocelot/bootstrap/exposed/InspectitWrapper.java
@@ -1,0 +1,8 @@
+package rocks.inspectit.ocelot.bootstrap.exposed;
+
+import java.util.function.BiConsumer;
+
+public interface InspectitWrapper {
+
+    <K, V> BiConsumer<K, V> wrap(BiConsumer<K, V> original);
+}

--- a/inspectit-ocelot-bootstrap/src/main/java/rocks/inspectit/ocelot/bootstrap/instrumentation/noop/NoopInspectitWrapper.java
+++ b/inspectit-ocelot-bootstrap/src/main/java/rocks/inspectit/ocelot/bootstrap/instrumentation/noop/NoopInspectitWrapper.java
@@ -1,0 +1,15 @@
+package rocks.inspectit.ocelot.bootstrap.instrumentation.noop;
+
+import rocks.inspectit.ocelot.bootstrap.exposed.InspectitWrapper;
+
+import java.util.function.BiConsumer;
+
+public class NoopInspectitWrapper implements InspectitWrapper {
+
+    public static final NoopInspectitWrapper INSTANCE = new NoopInspectitWrapper();
+
+    @Override
+    public <K, V> BiConsumer<K, V> wrap(BiConsumer<K, V> original) {
+        return original;
+    }
+}

--- a/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/instrumentation/actions/GenericActionSettings.java
+++ b/inspectit-ocelot-config/src/main/java/rocks/inspectit/ocelot/config/model/instrumentation/actions/GenericActionSettings.java
@@ -39,6 +39,7 @@ public class GenericActionSettings {
     public static final String REFLECTION_VARIABLE = "_reflection";
     public static final String REGEX_VARIABLE = "_regex";
     public static final String AGENT_VARIABLE = "_agent";
+    public static final String WRAPPER_VARIABLE = "_wrapper";
 
     private static final List<Pattern> SPECIAL_VARIABLES_REGEXES = Arrays.asList(
             Pattern.compile(THIS_VARIABLE),
@@ -53,7 +54,8 @@ public class GenericActionSettings {
             Pattern.compile(OBJECT_ATTACHMENTS_VARIABLE),
             Pattern.compile(REFLECTION_VARIABLE),
             Pattern.compile(REGEX_VARIABLE),
-            Pattern.compile(AGENT_VARIABLE)
+            Pattern.compile(AGENT_VARIABLE),
+            Pattern.compile(WRAPPER_VARIABLE)
     );
 
     /**
@@ -86,6 +88,7 @@ public class GenericActionSettings {
      * - _reflection: an {@link InspectitReflection} instance which allows you to access and cache fields or methods via reflection
      * - _regex: an {@link InspectitRegex} instance which allows to cache regex patterns and test strings
      * - _agent: an {@link InspectitAgentInfo} instance which allows to access meta information about the current agent
+     * - _wrapper: an {@link InspectitWrapper} instance which allows to wrap function interfaces
      * - _context: gives read and write access to the current {@link InspectitContext}, allowing you to attach values to the control flow
      * - _thrown: the {@link Throwable}-Object raised by the executed method, the type must be java.lang.Throwable
      * null if no throwable was raised
@@ -199,6 +202,12 @@ public class GenericActionSettings {
     private boolean isInspectitAgentInfoTypeCorrect() {
         String type = input.get(AGENT_VARIABLE);
         return type == null || "InspectitAgentInfo".equals(type);
+    }
+
+    @AssertTrue(message = "The '_wrapper' input must have the type 'InspectitWrapper'")
+    private boolean isInspectitWrapperTypeCorrect() {
+        String type = input.get(WRAPPER_VARIABLE);
+        return type == null || "InspectitWrapper".equals(type);
     }
 
     public static boolean isSpecialVariable(String varName) {

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/config/spring/BootstrapInitializerConfiguration.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/config/spring/BootstrapInitializerConfiguration.java
@@ -12,6 +12,7 @@ import rocks.inspectit.ocelot.bootstrap.opentelemetry.NoopOpenTelemetryControlle
 import rocks.inspectit.ocelot.config.model.InspectitConfig;
 import rocks.inspectit.ocelot.core.AgentInfoImpl;
 import rocks.inspectit.ocelot.core.config.InspectitEnvironment;
+import rocks.inspectit.ocelot.core.instrumentation.actions.InspectitWrapperImpl;
 import rocks.inspectit.ocelot.core.instrumentation.actions.cache.InspectitReflectionImpl;
 import rocks.inspectit.ocelot.core.instrumentation.actions.cache.InspectitRegexImpl;
 import rocks.inspectit.ocelot.core.instrumentation.config.InstrumentationConfigurationResolver;
@@ -72,6 +73,13 @@ public class BootstrapInitializerConfiguration {
         return regex;
     }
 
+    @Bean(InspectitWrapperImpl.BEAN_NAME)
+    public InspectitWrapperImpl getInspectitWrapper() {
+        InspectitWrapperImpl wrapper = new InspectitWrapperImpl();
+        Instances.wrapper = wrapper;
+        return wrapper;
+    }
+
     @Bean(LogTraceCorrelatorImpl.BEAN_NAME)
     public LogTraceCorrelatorImpl getLogTraceCorrelator(MdcAccessManager mdcAccessManager, InspectitEnvironment environment) {
         InspectitConfig configuration = environment.getCurrentConfig();
@@ -92,6 +100,7 @@ public class BootstrapInitializerConfiguration {
         Instances.agentInfo = NoopInspectitAgentInfo.INSTANCE;
         Instances.reflection = NoopInspectitReflection.INSTANCE;
         Instances.regex = NoopInspectitRegex.INSTANCE;
+        Instances.wrapper = NoopInspectitWrapper.INSTANCE;
         Instances.hookManager = NoopHookManager.INSTANCE;
         Instances.logTraceCorrelator = NoopLogTraceCorrelator.INSTANCE;
         Instances.traceIdInjector = NoopTraceIdInjector.INSTANCE;

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/instrumentation/actions/GenericActionGenerator.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/instrumentation/actions/GenericActionGenerator.java
@@ -146,7 +146,8 @@ public class GenericActionGenerator {
         }
 
         CtMethod method = action.getDeclaredMethod("executeImpl");
-        method.setBody(buildActionMethod(actionConfig));
+        String methodBody = buildActionMethod(actionConfig);
+        method.setBody(methodBody);
 
         return action.toBytecode();
     }

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/instrumentation/actions/InspectitWrapperImpl.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/instrumentation/actions/InspectitWrapperImpl.java
@@ -1,0 +1,19 @@
+package rocks.inspectit.ocelot.core.instrumentation.actions;
+
+import rocks.inspectit.ocelot.bootstrap.exposed.InspectitWrapper;
+
+import java.util.function.BiConsumer;
+
+public class InspectitWrapperImpl implements InspectitWrapper {
+
+    public static final String BEAN_NAME = "wrapper";
+
+    @Override
+    public <K, V> BiConsumer<K, V> wrap(BiConsumer<K, V> original) {
+        return (k,v) -> {
+            System.out.println("Before call");
+            original.accept(k, v);
+            System.out.println("After call");
+        };
+    }
+}

--- a/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/instrumentation/hook/VariableAccessorFactory.java
+++ b/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/instrumentation/hook/VariableAccessorFactory.java
@@ -3,10 +3,7 @@ package rocks.inspectit.ocelot.core.instrumentation.hook;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import rocks.inspectit.ocelot.bootstrap.exposed.InspectitAgentInfo;
-import rocks.inspectit.ocelot.bootstrap.exposed.ObjectAttachments;
-import rocks.inspectit.ocelot.bootstrap.exposed.InspectitReflection;
-import rocks.inspectit.ocelot.bootstrap.exposed.InspectitRegex;
+import rocks.inspectit.ocelot.bootstrap.exposed.*;
 import rocks.inspectit.ocelot.core.instrumentation.hook.actions.IHookAction;
 
 import static rocks.inspectit.ocelot.config.model.instrumentation.actions.GenericActionSettings.*;
@@ -32,6 +29,9 @@ public class VariableAccessorFactory {
 
     @Autowired
     private InspectitRegex inspectitRegex;
+
+    @Autowired
+    private InspectitWrapper inspectitWrapper;
 
     @Autowired
     private InspectitAgentInfo agentInfo;
@@ -102,6 +102,8 @@ public class VariableAccessorFactory {
                 return context -> inspectitRegex;
             case AGENT_VARIABLE:
                 return context -> agentInfo;
+            case WRAPPER_VARIABLE:
+                return context -> inspectitWrapper;
         }
         if (variable.startsWith(ARG_VARIABLE_PREFIX)) {
             try {
@@ -141,6 +143,8 @@ public class VariableAccessorFactory {
                 return inspectitRegex;
             case AGENT_VARIABLE:
                 return agentInfo;
+            case WRAPPER_VARIABLE:
+                return inspectitWrapper;
         }
         return null;
     }


### PR DESCRIPTION
Test for #1691

In order to prevent lambdas or anonymous classes for functional interfaces inside actions, we could use an internal class like in this example `InspectitWrapper`.

However, this try-out still misses some logic to actually reassign the wrapped objects back to the instrumented method.
If an Java object is overwritten within an entry-action, the instrumented method will still continue to use the original object.

Inside the class `DispatchHookAdvices` there is a hardcoded example, how to sucessfully overwrite method arguments (as an example).
